### PR TITLE
[Style] SignIn Page 퍼블리싱 #54 

### DIFF
--- a/src/api/firebaseApp.ts
+++ b/src/api/firebaseApp.ts
@@ -1,2 +1,14 @@
+import { initializeApp } from 'firebase/app'
 
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
+}
 
+const firebaseApp = initializeApp(firebaseConfig)
+
+export default firebaseApp

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,62 @@
+import { css } from '@emotion/react'
+import { Colors, FontSize } from '@/styles/Theme'
+import { ChangeEvent, useState } from 'react'
+import { FaRegEyeSlash, FaEyeSlash } from 'react-icons/fa'
+
+interface InputProps {
+  type?: 'text' | 'email' | 'password'
+  placeholder?: string
+  value?: string
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+}
+
+const inputStyle = css`
+  width: 327px;
+  height: 48px;
+  padding: 12px 16px;
+  border-radius: 3px;
+  border: 1px solid ${Colors.lightGrey};
+  font-size: ${FontSize.md};
+  color: ${Colors.black};
+  background-color: ${Colors.white};
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  position: relative;
+`
+
+const iconStyle = css`
+  position: absolute;
+  right: 16px;
+  cursor: pointer;
+  color: ${Colors.grey};
+`
+
+const Input = ({ type = 'text', placeholder, value, onChange }: InputProps) => {
+  const [showPassword, setShowPassword] = useState(false)
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword)
+  }
+
+  return (
+    <div css={inputStyle}>
+      <input
+        type={showPassword ? 'text' : type}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        css={{ flex: 1, border: 'none', outline: 'none' }}
+      />
+      {type === 'password' && (
+        <span
+          onClick={togglePasswordVisibility}
+          css={iconStyle}>
+          {showPassword ? <FaEyeSlash /> : <FaRegEyeSlash />}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default Input

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -7,8 +7,6 @@ import { useNavigate } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import { useFetchComments } from '@/hooks/useFetchComments'
 import { getAuth } from 'firebase/auth'
-import { useDeletePlaylist } from '@/hooks/useDeletePlaylist'
-import { useUpdatePlaylist } from '@/hooks/useUpdatePlaylist'
 import Toast from '@/components/common/Toast'
 import { useToggleBookmark } from '@/hooks/useToggleBookmark'
 
@@ -43,8 +41,6 @@ export default function Playlist({
     }
   }, [comments])
 
-  const { mutate: updatePlaylist } = useUpdatePlaylist()
-  const { mutate: deletePlaylist } = useDeletePlaylist()
   // playlist가 정의된 경우에만 useToggleBookmark를 호출하도록 수정
   const { toggleBookmark, isBookmarked } = playlist
     ? useToggleBookmark(playlist.id)
@@ -54,15 +50,17 @@ export default function Playlist({
   const [isToastVisible, setIsToastVisible] = useState(false)
 
   const handleBookmark = () => {
-    toggleBookmark()
+    if (playlist) {
+      toggleBookmark()
 
-    if (!isBookmarked) {
-      setToastMessage('북마크가 추가되었습니다.')
-    } else {
-      setToastMessage('북마크가 제거되었습니다.')
+      if (!isBookmarked) {
+        setToastMessage('북마크가 추가되었습니다.')
+      } else {
+        setToastMessage('북마크가 제거되었습니다.')
+      }
+
+      setIsToastVisible(true)
     }
-
-    setIsToastVisible(true)
   }
 
   const hideToast = () => {

--- a/src/hooks/useFetchUser
+++ b/src/hooks/useFetchUser
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { getFirestore, doc, getDoc } from 'firebase/firestore'
+
+export function useFetchUser(userId: string | undefined) {
+  const [userData, setUserData] = useState<any>(null)
+  const db = getFirestore()
+
+  useEffect(() => {
+    if (!userId) return
+
+    const fetchUserData = async () => {
+      const userRef = doc(db, 'users', userId)
+      const userSnap = await getDoc(userRef)
+
+      if (userSnap.exists()) {
+        setUserData(userSnap.data())
+      } else {
+        console.log('No such user!')
+      }
+    }
+
+    fetchUserData()
+  }, [userId])
+
+  return userData
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,3 @@
-import { initializeApp } from 'firebase/app'
-initializeApp({
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID
-})
-
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -53,13 +53,15 @@ export default function Home() {
     </>
   )
 }
-// 좋아요!
+
+// // 좋아요!
 // await addDoc(coll, {
 //   playlistId: '', // 참조(ref)
 //   userId: user?.uid, // 참조
 //   createdAt: new Date().toISOString()
 // })
-// 댓글
+
+// //댓글
 // await addDoc(coll, {
 //   playlistId: '', // 참조(ref)
 //   userId: user?.uid, // 참조

--- a/src/routes/pages/SignIn.tsx
+++ b/src/routes/pages/SignIn.tsx
@@ -1,19 +1,103 @@
+import { useState } from 'react'
 import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
 import { useNavigate } from 'react-router-dom'
+import backgroundImage from '@/assets/background.png'
+import logo from '@/assets/logo.png'
+import { css } from '@emotion/react'
+import LongButton from '@/components/common/LongButton'
+import Input from '@/components/common/Input'
+import firebaseApp from '@/api/firebaseApp'
+import { Colors } from '@/styles/Theme'
+import { create } from 'zustand'
+
+const containerStyle = css`
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: url(${backgroundImage});
+  background-size: cover;
+  background-position: center;
+  position: relative;
+  overflow: hidden;
+`
+
+const contentStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 1;
+  padding: 20px;
+`
+
+const logoStyle = css`
+  height: 60px;
+  width: 200px;
+  margin-bottom: 120px;
+`
+
+const formStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  margin-bottom: 130px;
+`
+const buttonContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`
+
+const signInButtonStyle = css`
+  background-color: ${Colors.black};
+  color: ${Colors.black};
+`
 
 export default function SignIn() {
   const provider = new GoogleAuthProvider()
-  const auth = getAuth()
+  const auth = getAuth(firebaseApp)
   const navigate = useNavigate()
 
   async function SignInWithGoogle() {
     await signInWithPopup(auth, provider)
     navigate('/')
   }
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
   return (
-    <>
-      <h1>로그인</h1>
-      <button onClick={SignInWithGoogle}>로그인</button>
-    </>
+    <div css={containerStyle}>
+      <div css={contentStyle}>
+        <img
+          css={logoStyle}
+          src={logo}
+          alt="Logo"
+        />
+        <div css={formStyle}>
+          <Input
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        <div css={buttonContainerStyle}>
+          <LongButton onClick={SignInWithGoogle}>로그인</LongButton>
+          <LongButton
+            css={signInButtonStyle}
+            onClick={SignInWithGoogle}>
+            회원가입
+          </LongButton>
+        </div>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

sign in 페이지의 UI를 구현하고 퍼블리싱을 완료했습니다.
비밀번호 암호화 해제 기능을 추가하였습니다.
오류가 있으나 추후 버그 브랜치에서 수정 예정입니다.

main.tsx에 있던 API 내용을 firebaseApp.ts로 이동시켰습니다.

## 📋 작업 내용

- Input 공통 컴포넌트 생성
- firebaseApp.ts 생성
- 비밀번호 암호화 해제 기능 추가
- assets 폴더에 background.png 추가

## 🔧 변경 사항

로그인 페이지 UI 퍼블리싱 구현

## 📸 스크린샷 (선택 사항)

![스크린샷 2024-09-17 오후 10 24 15](https://github.com/user-attachments/assets/ce9a9dd3-19a1-480b-b65e-787450ea23a0)
기본 signIn 페이지
![스크린샷 2024-09-17 오후 10 24 24](https://github.com/user-attachments/assets/c559a253-7028-4fa1-9a27-c22b14b22d36)
비밀번호 입력시 암호화
![스크린샷 2024-09-17 오후 10 24 30](https://github.com/user-attachments/assets/0b532ada-6ea4-4bd8-b962-70f101b4c6be)
아이콘 클릭시 비밀번호 암호화 해제
