### PR TITLE
[Setting] 파이어베이스 인증 관련 코드 리팩토링 #61

### DIFF
--- a/src/api/firebaseApp.ts
+++ b/src/api/firebaseApp.ts
@@ -1,4 +1,6 @@
 import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -12,3 +14,5 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig)
 
 export default firebaseApp
+export const db = getFirestore(firebaseApp)
+export const auth = getAuth(firebaseApp)

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { onAuthStateChanged, getAuth } from 'firebase/auth'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { css } from '@emotion/react'
 import whiteLogo from '@/assets/whiteLogo.png'
 import backgroundImage from '@/assets/background.png'
@@ -29,7 +30,6 @@ const logoStyle = css`
 
 export default function App() {
   const [isSplash, setIsSplash] = useState(true)
-  const auth = getAuth()
   const navigate = useNavigate()
 
   useEffect(() => {

--- a/src/components/common/LongButton.tsx
+++ b/src/components/common/LongButton.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from 'react'
 
 interface LongButtonProps {
   children: ReactNode
-  text: string
   onClick: () => void
   type?: 'button' | 'submit'
 }

--- a/src/components/common/PlaylistDetail.tsx
+++ b/src/components/common/PlaylistDetail.tsx
@@ -9,7 +9,7 @@ import { CgChevronUp, CgChevronDown } from 'react-icons/cg'
 import { css } from '@emotion/react'
 import { Colors } from '@/styles/Theme'
 import { FontSize } from '@/styles/Theme'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 
 const PlaylistDetail = () => {
   const setTitle = useHeaderStore(state => state.setTitle)
@@ -24,7 +24,6 @@ const PlaylistDetail = () => {
   const [comment, setComment] = useState('')
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(false)
 
-  const auth = getAuth()
   const user = auth.currentUser
 
   const { mutate: createComment } = useCreateComment()

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import { useNavigate } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import { useFetchComments } from '@/hooks/useFetchComments'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import Toast from '@/components/common/Toast'
 import { useToggleBookmark } from '@/hooks/useToggleBookmark'
 
@@ -30,7 +30,6 @@ export default function Playlist({
   const [isHeartFilled, setIsHeartFilled] = useState(false)
   const [commentCount, setCommentCount] = useState(0)
   const navigate = useNavigate()
-  const auth = getAuth()
   const user = auth.currentUser
 
   const { data: comments } = useFetchComments(playlist?.id || '')

--- a/src/hooks/useDeletePlaylist.ts
+++ b/src/hooks/useDeletePlaylist.ts
@@ -3,7 +3,7 @@
 
 import { useMutation } from '@tanstack/react-query'
 import { getFirestore, collection, doc, deleteDoc } from 'firebase/firestore'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 
 export interface Playlist {
   id: string
@@ -19,7 +19,6 @@ export const useDeletePlaylist = () => {
   return useMutation({
     mutationFn: async (playlist: Playlist) => {
       const db = getFirestore()
-      const auth = getAuth()
       const user = auth.currentUser
       const coll = collection(db, 'Playlists')
       const docRef = doc(coll, playlist.id)

--- a/src/hooks/useToggleBookmark.ts
+++ b/src/hooks/useToggleBookmark.ts
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { useBookmarkStore } from '@/stores/useBookmark'
 
 export const useToggleBookmark = (playlistId: string) => {
   const [isBookmarked, setIsBookmarked] = useState(false)
-  const auth = getAuth()
   const user = auth.currentUser
   const addBookmark = useBookmarkStore(state => state.addBookmark)
   const removeBookmark = useBookmarkStore(state => state.removeBookmark)

--- a/src/hooks/useUpdatePlaylist.ts
+++ b/src/hooks/useUpdatePlaylist.ts
@@ -3,7 +3,7 @@
 
 import { useMutation } from '@tanstack/react-query'
 import { getFirestore, collection, doc, updateDoc } from 'firebase/firestore'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 
 export interface Playlist {
   id: string
@@ -19,7 +19,6 @@ export const useUpdatePlaylist = () => {
   return useMutation({
     mutationFn: async (playlist: Playlist) => {
       const db = getFirestore()
-      const auth = getAuth()
       const user = auth.currentUser
       const coll = collection(db, 'Playlists')
       const docRef = doc(coll, playlist.id)

--- a/src/routes/pages/Bookmark.tsx
+++ b/src/routes/pages/Bookmark.tsx
@@ -4,14 +4,13 @@ import Playlist from '@/components/playlist/Playlist'
 import { useFetchPlaylists } from '@/hooks/useFetchPlaylists'
 import { useHeaderStore } from '@/stores/header'
 import { useEffect } from 'react'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { css } from '@emotion/react'
 import { useBookmarkStore } from '@/stores/useBookmark'
 
 const Bookmark = () => {
   const setTitle = useHeaderStore(state => state.setTitle)
   const { data: playlists } = useFetchPlaylists()
-  const auth = getAuth()
   const user = auth.currentUser
 
   const bookmarks = useBookmarkStore(state => state.bookmarks)

--- a/src/routes/pages/MyPlaylist.tsx
+++ b/src/routes/pages/MyPlaylist.tsx
@@ -3,7 +3,7 @@ import EmptyInfo from '@/components/emptyInfo/EmptyInfo'
 import { useFetchPlaylists } from '@/hooks/useFetchPlaylists'
 import { useHeaderStore } from '@/stores/header'
 import { useEffect } from 'react'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import SavedPlaylists from '@/routes/pages/SavedPlaylists'
 import { css } from '@emotion/react'
 
@@ -15,7 +15,6 @@ const MyPlaylist = () => {
   }, [setTitle])
 
   const { data } = useFetchPlaylists()
-  const auth = getAuth()
   const user = auth.currentUser
 
   // 현재 사용자와 일치하는 플레이리스트 필터링

--- a/src/routes/pages/PlaylistDetail.tsx
+++ b/src/routes/pages/PlaylistDetail.tsx
@@ -9,7 +9,7 @@ import { CgChevronUp, CgChevronDown } from 'react-icons/cg'
 import { css } from '@emotion/react'
 import { Colors } from '@/styles/Theme'
 import { FontSize } from '@/styles/Theme'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 
 const PlaylistDetail = () => {
   const setTitle = useHeaderStore(state => state.setTitle)
@@ -24,7 +24,6 @@ const PlaylistDetail = () => {
   const [comment, setComment] = useState('')
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(false)
 
-  const auth = getAuth()
   const user = auth.currentUser
 
   const { mutate: createComment } = useCreateComment()

--- a/src/routes/pages/Profile.tsx
+++ b/src/routes/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import LongButton from '@/components/common/LongButton'
 import { css } from '@emotion/react'
-import { getAuth, signOut } from 'firebase/auth'
+import { signOut } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { useNavigate } from 'react-router-dom'
 import { useHeaderStore } from '@/stores/header'
 import { useEffect } from 'react'
@@ -18,13 +19,12 @@ export default function Profile() {
     setTitle('Profile')
   }, [setTitle])
 
-  const auth = getAuth()
   const user = auth.currentUser
   const navigate = useNavigate()
 
   async function logOut() {
     await signOut(auth)
-    navigate('/login')
+    navigate('/SignIn')
   }
   return (
     <>

--- a/src/routes/pages/SavedPlaylists.tsx
+++ b/src/routes/pages/SavedPlaylists.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import { FontSize } from '@/styles/Theme'
 import { Colors } from '@/styles/Theme'
 import { useNavigate } from 'react-router-dom'
-import { getAuth } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { useState } from 'react'
 import { useDeletePlaylist } from '@/hooks/useDeletePlaylist'
 import { useUpdatePlaylist } from '@/hooks/useUpdatePlaylist'
@@ -30,7 +30,6 @@ export default function SavedPlaylists({ playlist }: { playlist: PlayList }) {
   const navigate = useNavigate()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isToastVisible, setIsToastVisible] = useState(false)
-  const auth = getAuth()
   const user = auth.currentUser
   const { mutate: updatePlayList } = useUpdatePlaylist()
   const { mutate: deletePlayList } = useDeletePlaylist()

--- a/src/routes/pages/SignIn.tsx
+++ b/src/routes/pages/SignIn.tsx
@@ -1,13 +1,12 @@
 import { useState } from 'react'
-import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
+import { signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import { useNavigate } from 'react-router-dom'
 import backgroundImage from '@/assets/background.png'
 import logo from '@/assets/logo.png'
 import { css } from '@emotion/react'
 import LongButton from '@/components/common/LongButton'
 import Input from '@/components/common/Input'
-import firebaseApp from '@/api/firebaseApp'
-import { Colors } from '@/styles/Theme'
 
 const containerStyle = css`
   height: 100vh;
@@ -48,14 +47,8 @@ const buttonContainerStyle = css`
   gap: 10px;
 `
 
-const signInButtonStyle = css`
-  background-color: ${Colors.black};
-  color: ${Colors.black};
-`
-
 export default function SignIn() {
   const provider = new GoogleAuthProvider()
-  const auth = getAuth(firebaseApp)
   const navigate = useNavigate()
 
   async function SignInWithGoogle() {
@@ -90,11 +83,7 @@ export default function SignIn() {
         </div>
         <div css={buttonContainerStyle}>
           <LongButton onClick={SignInWithGoogle}>로그인</LongButton>
-          <LongButton
-            css={signInButtonStyle}
-            onClick={SignInWithGoogle}>
-            회원가입
-          </LongButton>
+          <LongButton onClick={SignInWithGoogle}>회원가입</LongButton>
         </div>
       </div>
     </div>

--- a/src/routes/protected/RequiresAuth.tsx
+++ b/src/routes/protected/RequiresAuth.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Outlet, Navigate } from 'react-router-dom'
-import { getAuth, onAuthStateChanged } from 'firebase/auth'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '@/api/firebaseApp'
 import type { User } from 'firebase/auth'
 
 export default function RequiresAuth() {
@@ -10,7 +11,6 @@ export default function RequiresAuth() {
 
   useEffect(() => {
     setIsLoading(true)
-    const auth = getAuth()
     onAuthStateChanged(auth, user => {
       setUser(user)
       setIsLoading(false)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

파이어베이스 인증 관련 코드를 리팩토링하여 getAuth 호출을 제거하고, auth 객체를 직접 가져와 사용하는 방식으로 변경했습니다. 

## 📋 작업 내용

- firebaseApp.ts 파일에서 auth 객체를 직접 export하도록 변경했습니다.
- 모든 코드에서 getAuth 대신 auth를 import하여 사용하도록 수정했습니다.



