### PR TITLE
[Feature] 플레이리스트 내부 개별 동영상 리스트 구현

### DIFF
--- a/src/api/firebaseApp.ts
+++ b/src/api/firebaseApp.ts
@@ -8,7 +8,8 @@ const firebaseConfig = {
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  youtubeApiKey: import.meta.env.VITE_YOUTUBE_API_KEY
 }
 
 const firebaseApp = initializeApp(firebaseConfig)

--- a/src/components/common/PlaylistDetail.tsx
+++ b/src/components/common/PlaylistDetail.tsx
@@ -154,21 +154,25 @@ export default function PlaylistDetail({
 
       <div css={plAmountInfoStyle}>
         <CgPlayList className="cgPlaylist" />
-        재생목록({playlistData.urls.length})
+        재생목록 ({playlistData.urls.length})
       </div>
-      <div>
+      <div css={videoContainerStyle}>
         {playlistData.urls.map((url, index) => (
-          <div key={index}>
+          <div
+            key={index}
+            css={videoInfoLayoutStyle}>
             <img
               src={extractThumbnailUrl(url)}
               alt={`Video thumbnail ${index + 1}`}
-              width="240"
-              height="135"
+              width="80"
+              height="60"
               onClick={() => setCurrentVideoUrl(url)}
-              style={{ cursor: 'pointer' }}
+              style={{ cursor: 'pointer', borderRadius: '8px' }}
             />
-            <span>{videoTitles[index] || '제목 로딩 중...'}</span>
-            <CgFormatJustify />
+            <span css={videoTitleStyle}>
+              {videoTitles[index] || '제목 로딩 중...'}
+            </span>
+            <CgFormatJustify css={dragIconStyle} />
           </div>
         ))}
       </div>
@@ -264,4 +268,31 @@ const lockStyle = css`
   font-size: ${theme.fontSize.md};
   display: flex;
   gap: 5px;
+`
+
+const videoContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 20px;
+  margin-top: 10px;
+  gap: 20px;
+`
+
+const videoInfoLayoutStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+`
+const videoTitleStyle = css`
+  flex-grow: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+`
+
+const dragIconStyle = css`
+  flex-shrink: 0;
 `

--- a/src/components/common/PlaylistDetail.tsx
+++ b/src/components/common/PlaylistDetail.tsx
@@ -22,12 +22,9 @@ import 'dayjs/locale/ko'
 dayjs.locale('ko')
 dayjs.extend(relativeTime)
 
-function extractVideoId(url?: string) {
-  if (!url) {
-    console.error('URL is undefined or empty')
-    return ''
-  }
-  return url.replace('https://www.youtube.com/watch?v=', '')
+function extractThumbnailUrl(url: string) {
+  const videoId = url.replace('https://www.youtube.com/watch?v=', '')
+  return `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
 }
 
 export default function PlaylistDetail({
@@ -43,6 +40,7 @@ export default function PlaylistDetail({
   const { id } = useParams()
   const { data: playlistData, isLoading } = useFetchPlaylist(id as string)
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(false)
+  const [currentVideoUrl, setCurrentVideoUrl] = useState<string | null>(null)
   const [filteredPlaylists, setFilteredPlaylists] = useState<
     (typeof Playlist)[] | null
   >(null)
@@ -53,6 +51,12 @@ export default function PlaylistDetail({
     setTitle('Playlist Detail')
   }, [setTitle])
 
+  useEffect(() => {
+    if (playlistData && playlistData.urls.length > 0) {
+      setCurrentVideoUrl(playlistData.urls[0])
+    }
+  }, [playlistData])
+
   if (isLoading) {
     return <div>로딩 중...</div>
   }
@@ -61,16 +65,14 @@ export default function PlaylistDetail({
     return <div>플레이리스트 데이터를 가져오지 못했습니다.</div>
   }
 
-  const videoUrl = playlistData.urls[0]
-
   return (
     <div>
       <div css={sectionOneContainer}>
-        {videoUrl ? (
+        {currentVideoUrl ? (
           <iframe
             width="100%"
             height="240px"
-            src={videoUrl.replace('watch?v=', 'embed/')}
+            src={currentVideoUrl.replace('watch?v=', 'embed/')}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
             title="YouTube video"></iframe>
@@ -123,8 +125,25 @@ export default function PlaylistDetail({
 
       <div css={plAmountInfoStyle}>
         <CgPlayList className="cgPlaylist" />
-        재생목록( )
+        재생목록({playlistData.urls.length})
       </div>
+      <div>
+        {playlistData.urls.map((url, index) => (
+          <div key={index}>
+            <img
+              src={extractThumbnailUrl(url)}
+              alt={`Video thumbnail ${index + 1}`}
+              width="240"
+              height="135"
+              onClick={() => setCurrentVideoUrl(url)}
+              style={{ cursor: 'pointer' }}
+            />
+            <span>{}</span>
+            <CgFormatJustify />
+          </div>
+        ))}
+      </div>
+      <div className="nav-margin"></div>
     </div>
   )
 }

--- a/src/components/layouts/headers/TheHeader.tsx
+++ b/src/components/layouts/headers/TheHeader.tsx
@@ -4,6 +4,7 @@ import { CgChevronLeft } from 'react-icons/cg'
 import { useHeaderStore } from '@/stores/header'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAddPlaylistStore } from '@/stores/addPlaylist'
+import { Playlist } from '@/hooks/useFetchPlaylists'
 
 const headerStyle = css`
   display: flex;
@@ -57,7 +58,7 @@ const logoStyle = css`
   height: 25px;
 `
 
-export default function TheHeader(id: string) {
+export default function TheHeader(id: string, playlist: Playlist) {
   const title = useHeaderStore(state => state.title)
   const navigate = useNavigate()
   const location = useLocation()
@@ -73,6 +74,10 @@ export default function TheHeader(id: string) {
     } catch (error) {
       console.error('저장 실패:', error)
     }
+  }
+
+  const handleEdit = (playlist: Playlist) => {
+    navigate(`/edit-playlist/${playlist.id}`, { state: { playlist } })
   }
 
   return (
@@ -101,7 +106,15 @@ export default function TheHeader(id: string) {
         </button>
       )}
       {isProfile && <button css={editBtn}>수정</button>}
-      {isMyPlaylist && <button css={editBtn}>편집</button>}
+      {isMyPlaylist && (
+        <button
+          css={editBtn}
+          onClick={() => {
+            handleEdit(playlist)
+          }}>
+          편집
+        </button>
+      )}
     </header>
   )
 }

--- a/src/components/layouts/navigations/TheNavigation.tsx
+++ b/src/components/layouts/navigations/TheNavigation.tsx
@@ -86,6 +86,7 @@ const addButtonStyle = css`
     svg {
       font-size: 40px;
       stroke-width: 0;
+      color: ${theme.colors.black};
     }
   }
   &.active {

--- a/src/hooks/useDeletePlaylist.ts
+++ b/src/hooks/useDeletePlaylist.ts
@@ -1,7 +1,7 @@
 // GET - useQuery
 // POST, PUT, PATCH, DELETE - useMutation
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { getFirestore, collection, doc, deleteDoc } from 'firebase/firestore'
 import { auth } from '@/api/firebaseApp'
 
@@ -16,6 +16,7 @@ export interface Playlist {
 }
 
 export const useDeletePlaylist = () => {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (playlist: Playlist) => {
       const db = getFirestore()
@@ -25,6 +26,9 @@ export const useDeletePlaylist = () => {
       if (user && playlist.userId === user.uid) {
         await deleteDoc(docRef)
       }
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: ['playlists'] })
     }
   })
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import Profile from '@/routes/pages/Profile'
 import PlaylistDetail from '@/routes/pages/PlaylistDetail'
 import SavedPlaylistDetail from '@/routes/pages/SavedPlaylistsDetail'
 import RequiresAuth from '@/routes/protected/RequiresAuth'
+import EditPlaylist from '@/routes/pages/EditPlaylist'
 import SignIn from './pages/SignIn'
 import NotFound from './pages/NotFound'
 import dayjs from 'dayjs'
@@ -28,6 +29,7 @@ export const router = createBrowserRouter([
           { path: '/bookmark', element: <Bookmark /> },
           { path: '/my-playlist', element: <MyPlaylist /> },
           { path: '/saved-playlists/:id', element: <SavedPlaylistDetail /> },
+          { path: '/edit-playlist/:id', element: <EditPlaylist /> },
           { path: '/profile', element: <Profile /> }
         ]
       }

--- a/src/routes/pages/EditPlaylist.tsx
+++ b/src/routes/pages/EditPlaylist.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const EditPlaylist = () => {
+  return <div>EditPlaylist</div>
+}
+
+export default EditPlaylist


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

플레이리스트 내부 개별 동영상 리스트 구현

## 📋 작업 내용

- useDeletePlaylist 훅 수정
- 플레이리스트에 저장된 동영상 썸네일, 제목 불러오기
- 동영상들 표시되는 부분 UI 만들기
- 네비게이션에 + 버튼 색상 블랙으로 변경

## 🔧 변경 사항
- 주요 변경 사항
useDeletePlaylist 훅에 onSuccess 붙여서 삭제하자마자 해당 플레이리스트 없어지도록 구현
플레이리스트에 저장된 각 동영상 제목을 유튜브 API에서 불러오는 기능 추가

## 📸 스크린샷 (선택 사항)
<img width="542" alt="image" src="https://github.com/user-attachments/assets/0fa0c536-1b4e-4e8e-93f6-70fc158595f1">

## 📄 기타

따로 전달드린 API_KEY를 .env 파일에 추가해주세요
