### PR TITLE
[Feature] 공개 설정 기능 구현 #97

### DIFF
--- a/src/components/playlist/PlaylistDetail.tsx
+++ b/src/components/playlist/PlaylistDetail.tsx
@@ -767,11 +767,10 @@
 // ------------------------------------------------------------------------------------------------------------------------
 // 내것만 드래그앤드롭 가능
 
-import { getFirestore, doc, updateDoc } from 'firebase/firestore'
+import { getFirestore, doc, getDoc } from 'firebase/firestore'
 import { useState, useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { useHeaderStore } from '@/stores/header'
-import { useFetchPlaylist } from '@/hooks/useFetchPlaylist'
 import {
   CgChevronUp,
   CgChevronDown,
@@ -832,7 +831,8 @@ export default function PlaylistDetail({
 }) {
   const setTitle = useHeaderStore(state => state.setTitle)
   const { id } = useParams()
-  const { data: playlistData, isLoading } = useFetchPlaylist(id as string)
+  const [playlistData, setPlaylistData] = useState<any>(null)
+  const [isLoading, setIsLoading] = useState(true)
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(false)
   const [currentVideoUrl, setCurrentVideoUrl] = useState<string | null>(null)
   const [videoTitles, setVideoTitles] = useState<string[]>([])
@@ -840,13 +840,41 @@ export default function PlaylistDetail({
   const openEdit = () => setIsEditOpen(true)
   const closeEdit = () => setIsEditOpen(false)
   const user = auth.currentUser
-  const ItemRef = useRef<HTMLDivElement | null>(null) // 드래그앤드롭을 위한 거
-  const db = getFirestore() // 드래그 추가
+  const ItemRef = useRef<HTMLDivElement | null>(null)
+  const db = getFirestore()
   const isOwner = user?.uid === playlistData?.userId
 
   useEffect(() => {
     setTitle('Playlist Detail')
   }, [setTitle])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const playlistDocRef = doc(db, 'Playlists', id!)
+        const publicPlaylistDocRef = doc(db, 'PublicPlaylists', id!)
+        
+        const [playlistSnap, publicPlaylistSnap] = await Promise.all([
+          getDoc(playlistDocRef),
+          getDoc(publicPlaylistDocRef)
+        ])
+
+        if (playlistSnap.exists()) {
+          setPlaylistData({ id: playlistSnap.id, ...playlistSnap.data() })
+        } else if (publicPlaylistSnap.exists()) {
+          setPlaylistData({ id: publicPlaylistSnap.id, ...publicPlaylistSnap.data() })
+        } else {
+          console.log("No matching documents found in either collection.")
+        }
+      } catch (error) {
+        console.error("Error fetching playlist data:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [id, db])
 
   useEffect(() => {
     if (playlistData && playlistData.urls.length > 0) {
@@ -859,7 +887,7 @@ export default function PlaylistDetail({
         const titles = await Promise.all(
           videoIds.map(id => fetchVideoTitle(id))
         )
-        setVideoTitles(titles) // 제목 배열 상태로 설정
+        setVideoTitles(titles)
       }
 
       fetchTitles()
@@ -868,8 +896,7 @@ export default function PlaylistDetail({
 
   useEffect(() => {
     if (!ItemRef.current || !playlistData || !playlistData.urls || !isOwner)
-      return // 소유자가 아닐 경우 초기화하지 않음
-    console.log('Sortable 초기화 완료:', playlistData.urls)
+      return
 
     new Sortable(ItemRef.current, {
       handle: '.drag-handle',
@@ -877,30 +904,19 @@ export default function PlaylistDetail({
       forceFallback: false,
       onEnd: async event => {
         if (event.oldIndex === undefined || event.newIndex === undefined) return
-        console.log(
-          '드래그앤드롭 이벤트 발생:',
-          event.oldIndex,
-          '->',
-          event.newIndex
-        )
 
         const newUrls = Array.from(playlistData.urls)
         const [movedItem] = newUrls.splice(event.oldIndex, 1)
         newUrls.splice(event.newIndex, 0, movedItem)
-        console.log('변경된 URL 배열:', newUrls)
 
-        // Firestore에 업데이트
         if (id) {
           const playlistRef = doc(db, 'Playlists', id)
           await updateDoc(playlistRef, {
             urls: newUrls
           })
-          console.log('Firestore에 업데이트 완료')
         }
 
-        // 상태를 업데이트하여 UI에 즉시 반영
         setCurrentVideoUrl(newUrls[0])
-        console.log('현재 재생 중인 비디오 URL 업데이트:', newUrls[0])
       }
     })
   }, [playlistData, id, db, isOwner])
@@ -1018,7 +1034,6 @@ export default function PlaylistDetail({
   )
 }
 
-// CSS 스타일은 기존과 동일하게 유지
 const sectionOneContainer = css`
   iframe {
   }
@@ -1142,3 +1157,4 @@ const videoTitleStyle = css`
 const dragIconStyle = css`
   flex-shrink: 0;
 `
+

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -18,7 +18,7 @@ export default function Home() {
     setTitle('Home');
   }, [setTitle]);
 
-  const { data, isLoading } = useFetchPlaylists();
+  const { data, isLoading } = useFetchPlaylists(false);
 
   const handlePlaylistClick = (playlist: PlaylistType) => {
     navigate(`/playlist/${playlist.id}`, { state: { playlist } });

--- a/src/routes/pages/MyPlaylist.tsx
+++ b/src/routes/pages/MyPlaylist.tsx
@@ -14,10 +14,9 @@ const MyPlaylist = () => {
     setTitle('My Playlist')
   }, [setTitle])
 
-  const { data } = useFetchPlaylists()
+  const { data } = useFetchPlaylists(true)
   const user = auth.currentUser
 
-  // 현재 사용자와 일치하는 플레이리스트 필터링
   const filteredPlaylists = data?.filter(pl => pl.userId === user?.uid)
 
   return (

--- a/src/stores/addPlaylist.ts
+++ b/src/stores/addPlaylist.ts
@@ -49,7 +49,7 @@ export const useAddPlaylistStore = create<PlaylistState>((set, get) => ({
       throw new Error('사용자가 인증되지 않았습니다.')
     }
 
-    const coll = collection(db, 'Playlists')
+    const coll = isPublic ? collection(db, 'Playlists') : collection(db, 'PublicPlaylists')
 
     await addDoc(coll, {
       urls: videoUrls,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

공개 설정 기능 구현

## 📋 작업 내용

게시글 추가할 때 공개 설정시 홈, 마이플리 에 플레이리스트가 뜨도록 했습니다.
비공개 설정시 마이플리에만 플레이스트가 뜨도록 하였습니다.

## 🔧 변경 사항

- addPlaylist.ts
  +  `const coll = isPublic ? collection(db, 'Playlists') : collection(db, 'PublicPlaylists')`
공개설정시 Playlists  에 데이터 저장, 비공개 설정시 PublicPlaylists 에 데이터 저장

- Home.tsx
  + `const { data, isLoading } = useFetchPlaylists(false)`
false 로 설정시 홈과 마이플리 둘다에 동영상이 올라감

- MyPlaylist.tsx
  +  `const { data } = useFetchPlaylists(true)`
true 로 설정시 마이플리에만 동영상이 올라감

- useFetchPlaylists.ts
![7](https://github.com/user-attachments/assets/7763be60-19ef-4647-8ff4-9f0c81efa763)
기존 코드를 최대한 유지한채 PublicPlaylists 만 추가하는 방향으로 진행했습니다.

- PlaylistDetail.tsx
![9](https://github.com/user-attachments/assets/48870d91-64b6-4ed7-bf61-fbeb88053127)
전반적으로 PublicPlaylists 의 데이터베이스를 추가했습니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

오류 해결 메모

![2](https://github.com/user-attachments/assets/b421e5b4-c023-4041-9b3c-231ff5189bc5)

공개와 비공개 데이터를 따로 관리하게 되면서 기존에는 Playlists 데이터만 불러와서 디테일 페이지가 잘 작동했지만
파일이 분리되면서 PublicPlaylists 의 데이터가 자꾸 데이터를 불러오지못했습니다 에러가 났습니다.
여러가지 시도해보면서 마지막으로 해결된게 그냥 기존 db, Playlists 의 아래쪽에 db, PublicPlaylists 를 추가하는 것이었습니다.

![3](https://github.com/user-attachments/assets/bae221fe-6171-4b68-9b83-9137a0f2986c)

## 마이플레이리스트에서 비공개 게시글을 잘 가지고 온 모습

![4](https://github.com/user-attachments/assets/94cf6bb9-9c16-4854-9ac5-3a2e5ff8faa2)

### 공개 동영상의 디테일 페이지는 잘 작동하는 모습

![5](https://github.com/user-attachments/assets/01d3206c-b1c4-4637-ae4e-d2e99bc63105)

### 비공개 동영상 디테일 페이지에 데이터를 불러 오지 못한 모습

![6](https://github.com/user-attachments/assets/b4e6cc87-8532-411a-8340-99f2c4bf1dcf)


