### PR TITLE
[Feature] EditplaylistInfo 정보 수정 페이지 기능 구현

### DIFF
--- a/src/components/layouts/headers/TheHeader.tsx
+++ b/src/components/layouts/headers/TheHeader.tsx
@@ -5,6 +5,77 @@ import { useHeaderStore } from '@/stores/header'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAddPlaylistStore } from '@/stores/addPlaylist'
 import { Playlist } from '@/hooks/useFetchPlaylists'
+import { useEditPlaylistInfo } from '@/hooks/useEditPlaylistInfo'
+
+export default function TheHeader() {
+  const title = useHeaderStore(state => state.title)
+  const handleClickRightButton = useHeaderStore(
+    state => state.handleClickRightButton
+  )
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { isDone, savePlaylist, isPublic } = useAddPlaylistStore()
+  const isAddPlaylist = location.pathname === '/add-playlist'
+  const isEditPlaylist = location.pathname.includes('/edit-playlist')
+  const isDeleteVideos = location.pathname.includes('/delete-videos')
+  const isProfile = location.pathname === '/profile'
+
+  const handleComplete = async () => {
+    try {
+      await savePlaylist()
+      if (isPublic) {
+        navigate('/', { state: { showToast: true } })
+      } else {
+        navigate('/')
+      }
+    } catch (error) {
+      console.error('저장 실패:', error)
+    }
+  }
+
+  return (
+    <header css={headerStyle}>
+      {(title === '플레이리스트 상세보기' || title === '플레이리스트 편집') && (
+        <CgChevronLeft
+          css={iconStyle}
+          onClick={() => navigate(-1)}
+        />
+      )}
+      {title === 'Home' ? (
+        <img
+          css={logoStyle}
+          src="/src/assets/logo.png"
+          alt="logo"
+        />
+      ) : (
+        <h2 css={titleStyle}>{title}</h2>
+      )}
+      {isAddPlaylist && (
+        <button
+          css={successBtn(isDone)}
+          onClick={isDone ? handleComplete : undefined}
+          disabled={!isDone}>
+          완료
+        </button>
+      )}
+      {isEditPlaylist && (
+        <button
+          css={okayButtonStyle}
+          onClick={handleClickRightButton}>
+          수정
+        </button>
+      )}
+      {isDeleteVideos && (
+        <button
+          css={okayButtonStyle}
+          onClick={() => {}}>
+          삭제
+        </button>
+      )}
+      {isProfile && <button css={editBtn}>수정</button>}
+    </header>
+  )
+}
 
 const headerStyle = css`
   display: flex;
@@ -67,70 +138,3 @@ const logoStyle = css`
   width: 80px;
   height: 25px;
 `
-
-export default function TheHeader(id: string, playlist: Playlist) {
-  const title = useHeaderStore(state => state.title)
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { isDone, savePlaylist, isPublic } = useAddPlaylistStore()
-  const isAddPlaylist = location.pathname === '/add-playlist'
-  const isEditPlaylist = location.pathname.includes('/edit-playlist')
-  const isDeleteVideos = location.pathname.includes('/delete-videos')
-  const isProfile = location.pathname === '/profile'
-
-  const handleComplete = async () => {
-    try {
-      await savePlaylist()
-      if (isPublic) {
-        navigate('/', { state: { showToast: true } })
-      } else {
-        navigate('/')
-      }
-    } catch (error) {
-      console.error('저장 실패:', error)
-    }
-  }
-
-  return (
-    <header css={headerStyle}>
-      {(title === '플레이리스트 상세보기' || title === '플레이리스트 편집') && (
-        <CgChevronLeft
-          css={iconStyle}
-          onClick={() => navigate(-1)}
-        />
-      )}
-      {title === 'Home' ? (
-        <img
-          css={logoStyle}
-          src="/src/assets/logo.png"
-          alt="logo"
-        />
-      ) : (
-        <h2 css={titleStyle}>{title}</h2>
-      )}
-      {isAddPlaylist && (
-        <button
-          css={successBtn(isDone)}
-          onClick={isDone ? handleComplete : undefined}
-          disabled={!isDone}>
-          완료
-        </button>
-      )}
-      {isEditPlaylist && (
-        <button
-          css={okayButtonStyle}
-          onClick={() => {}}>
-          수정
-        </button>
-      )}
-      {isDeleteVideos && (
-        <button
-          css={okayButtonStyle}
-          onClick={() => {}}>
-          삭제
-        </button>
-      )}
-      {isProfile && <button css={editBtn}>수정</button>}
-    </header>
-  )
-}

--- a/src/components/layouts/headers/TheHeader.tsx
+++ b/src/components/layouts/headers/TheHeader.tsx
@@ -74,8 +74,8 @@ export default function TheHeader(id: string, playlist: Playlist) {
   const location = useLocation()
   const { isDone, savePlaylist, isPublic } = useAddPlaylistStore()
   const isAddPlaylist = location.pathname === '/add-playlist'
-  const isEditPlaylist = location.pathname === '/edit-playlist'
-  const isDeleteVideos = location.pathname === '/delete-videos'
+  const isEditPlaylist = location.pathname.includes('/edit-playlist')
+  const isDeleteVideos = location.pathname.includes('/delete-videos')
   const isProfile = location.pathname === '/profile'
 
   const handleComplete = async () => {

--- a/src/components/playlist/EditPlaylistModal.tsx
+++ b/src/components/playlist/EditPlaylistModal.tsx
@@ -1,11 +1,17 @@
 import { css } from '@emotion/react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
+import { Playlist, useFetchPlaylist } from '@/hooks/useFetchPlaylist'
 import { CgClose } from 'react-icons/cg'
 import theme from '@/styles/theme'
 import LongButton from '@/components/common/LongButton'
 
-const EditPlaylist = ({ closeEdit }: { closeEdit: () => void }) => {
+interface PlayListProps {
+  closeEdit: () => void
+  playlist: Playlist // 부모 컴포넌트로부터 playlist 전달 받음
+}
+
+const EditPlaylist = ({ closeEdit, playlist }: PlayListProps) => {
   const pageEffect = {
     hidden: {
       opacity: 0,
@@ -29,11 +35,21 @@ const EditPlaylist = ({ closeEdit }: { closeEdit: () => void }) => {
 
   const navigate = useNavigate()
 
-  const handleEditInfo = () => {
-    navigate('/edit-playlist')
+  // EditPlaylist 컴포넌트
+  const handleEditInfo = (playlist: Playlist) => {
+    if (!playlist) {
+      console.error('Playlist data is missing')
+      return
+    }
+    navigate(`/edit-playlist/${playlist.id}`, { state: { playlist } })
   }
-  const handleDelete = () => {
-    navigate('/delete-videos')
+
+  const handleDelete = (playlist: Playlist) => {
+    if (!playlist) {
+      console.error('Playlist data is missing')
+      return
+    }
+    navigate(`/delete-videos/${playlist.id}`, { state: { playlist } })
   }
 
   return (
@@ -59,8 +75,12 @@ const EditPlaylist = ({ closeEdit }: { closeEdit: () => void }) => {
             <CgClose fontSize={theme.fontSize.lg} />
           </button>
           <div css={longButtonStyle}>
-            <LongButton onClick={handleEditInfo}>정보 수정</LongButton>
-            <LongButton onClick={handleDelete}>동영상 삭제</LongButton>
+            <LongButton onClick={() => handleEditInfo(playlist)}>
+              정보 수정
+            </LongButton>
+            <LongButton onClick={() => handleDelete(playlist)}>
+              동영상 삭제
+            </LongButton>
           </div>
         </div>
       </>

--- a/src/components/playlist/PlaylistDetail.tsx
+++ b/src/components/playlist/PlaylistDetail.tsx
@@ -78,7 +78,7 @@ export default function PlaylistDetail({
   const isOwner = user?.uid === playlistData?.userId
 
   useEffect(() => {
-    setTitle('Playlist Detail')
+    setTitle('플레이리스트 상세보기')
   }, [setTitle])
 
   useEffect(() => {
@@ -200,7 +200,12 @@ export default function PlaylistDetail({
           )}
         </div>
         <AnimatePresence>
-          {isEditOpen && <EditPlaylistModal closeEdit={closeEdit} />}
+          {isEditOpen && (
+            <EditPlaylistModal
+              closeEdit={closeEdit}
+              playlist={playlistData}
+            />
+          )}
         </AnimatePresence>
         <div css={otherInfoStyle}>
           {showLockIcon && (

--- a/src/hooks/useEditPlaylistInfo.ts
+++ b/src/hooks/useEditPlaylistInfo.ts
@@ -23,7 +23,6 @@ export const useEditPlaylistInfo = () => {
       // Firestore 컬렉션 참조
       const coll = collection(db, 'Playlists')
       const docRef = doc(coll, playlist.id) // 수정할 문서 참조
-      console.log(playlist)
       // 현재 로그인한 사용자가 플레이리스트의 소유자일 때만 업데이트 수행
       if (user && playlist.userId === user.uid) {
         await updateDoc(docRef, {

--- a/src/hooks/useEditPlaylistInfo.ts
+++ b/src/hooks/useEditPlaylistInfo.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { getFirestore, collection, doc, updateDoc } from 'firebase/firestore'
+import { auth } from '@/api/firebaseApp'
+
+export interface Playlist {
+  id: string
+  title: string
+  description: string
+  isPublic: boolean
+  categories: string[]
+  userId: string
+  createdAt: string
+}
+
+export const useEditPlaylistInfo = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (playlist: Playlist) => {
+      const db = getFirestore() // Firestore 인스턴스 가져오기
+      const user = auth.currentUser // 현재 로그인한 사용자 정보 가져오기
+
+      // Firestore 컬렉션 참조
+      const coll = collection(db, 'Playlists')
+      const docRef = doc(coll, playlist.id) // 수정할 문서 참조
+      console.log(playlist)
+      // 현재 로그인한 사용자가 플레이리스트의 소유자일 때만 업데이트 수행
+      if (user && playlist.userId === user.uid) {
+        await updateDoc(docRef, {
+          title: playlist.title,
+          description: playlist.description,
+          isPublic: playlist.isPublic,
+          categories: playlist.categories
+        })
+      } else {
+        throw new Error("You don't have permission to edit this playlist.")
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['playlists'] })
+    }
+  })
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -32,8 +32,8 @@ export const router = createBrowserRouter([
           { path: '/bookmarked-playlist/:id', element: <BookmarkedPlaylist /> },
           { path: '/my-playlist', element: <MyPlaylist /> },
           { path: '/saved-playlists/:id', element: <SavedPlaylistDetail /> },
-          { path: '/edit-playlist', element: <EditPlaylistInfo /> },
-          { path: '/delete-videos', element: <DeleteVideos /> },
+          { path: '/edit-playlist/:id', element: <EditPlaylistInfo /> },
+          { path: '/delete-videos/:id', element: <DeleteVideos /> },
           { path: '/profile', element: <Profile /> }
         ]
       }

--- a/src/routes/pages/EditPlaylistInfo.tsx
+++ b/src/routes/pages/EditPlaylistInfo.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import Category from '@/components/common/Category'
 import { Playlist } from '@/hooks/useFetchPlaylists'
+import { useEditPlaylistInfo } from '@/hooks/useEditPlaylistInfo'
 
 export default function EditPlaylistInfo() {
   const setTitle = useHeaderStore(state => state.setTitle)
@@ -55,10 +56,12 @@ export default function EditPlaylistInfo() {
     setSelectedCategories(categories)
   }
 
-  const handleSave = async () => {
+  const handleEdit = async () => {
     // 데이터 저장 로직 구현 (예: Firebase 업데이트)
     try {
-      // 예시로 console.log로 데이터 확인
+      if (playlist) {
+        editPlaylist.mutate(playlist)
+      }
       console.log({
         title: videoTitle,
         description: videoDescription,
@@ -72,6 +75,8 @@ export default function EditPlaylistInfo() {
       console.error('Error saving playlist:', error)
     }
   }
+
+  const editPlaylist = useEditPlaylistInfo()
 
   return (
     <>
@@ -140,8 +145,7 @@ export default function EditPlaylistInfo() {
         </label>
 
         <div>
-          <button onClick={handleSave}>저장</button>
-          <button onClick={() => navigate(-1)}>취소</button>
+          <button onClick={handleEdit}>저장</button>
         </div>
       </div>
       <div className="nav-margin-bottom"></div>

--- a/src/routes/pages/EditPlaylistInfo.tsx
+++ b/src/routes/pages/EditPlaylistInfo.tsx
@@ -2,14 +2,30 @@ import { css } from '@emotion/react'
 import theme from '@/styles/theme'
 import { useHeaderStore } from '@/stores/header'
 import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import Category from '@/components/common/Category'
+import { Playlist } from '@/hooks/useFetchPlaylists'
 
 export default function EditPlaylistInfo() {
   const setTitle = useHeaderStore(state => state.setTitle)
+  const location = useLocation() // playlist 데이터를 받기 위함
+  const navigate = useNavigate()
+
+  // location에서 playlist 데이터 가져오기
+  const playlist = location.state?.playlist as Playlist | undefined
 
   useEffect(() => {
+    if (!playlist) {
+      console.error('Playlist not found')
+      navigate(-1) // 데이터가 없으면 이전 페이지로 돌아감
+      return
+    }
     setTitle('플레이리스트 편집')
-  }, [setTitle])
+    setVideoTitle(playlist.title)
+    setVideoDescription(playlist.description)
+    setIsPublic(playlist.isPublic)
+    setSelectedCategories(playlist.categories || ['전체'])
+  }, [playlist, navigate])
 
   const [videoTitle, setVideoTitle] = useState('')
   const [videoDescription, setVideoDescription] = useState('')
@@ -39,6 +55,24 @@ export default function EditPlaylistInfo() {
     setSelectedCategories(categories)
   }
 
+  const handleSave = async () => {
+    // 데이터 저장 로직 구현 (예: Firebase 업데이트)
+    try {
+      // 예시로 console.log로 데이터 확인
+      console.log({
+        title: videoTitle,
+        description: videoDescription,
+        isPublic,
+        categories: selectedCategories
+      })
+
+      // 저장 후 페이지 이동 (리다이렉션)
+      navigate(-1) // 이전 페이지로 돌아가기
+    } catch (error) {
+      console.error('Error saving playlist:', error)
+    }
+  }
+
   return (
     <>
       <div className="nav-margin-top"></div>
@@ -50,10 +84,7 @@ export default function EditPlaylistInfo() {
           type="text"
           placeholder="제목을 입력해주세요."
           value={videoTitle}
-          onChange={e => {
-            setVideoTitle(e.target.value)
-            onTitleInputHandler(e)
-          }}
+          onChange={onTitleInputHandler}
           css={TitleInputContainer}
           maxLength={15}
         />
@@ -66,10 +97,7 @@ export default function EditPlaylistInfo() {
         <textarea
           placeholder="설명을 입력해주세요."
           value={videoDescription}
-          onChange={e => {
-            setVideoDescription(e.target.value)
-            onDescriptionInputHandler(e)
-          }}
+          onChange={onDescriptionInputHandler}
           rows={3}
           maxLength={30}
           css={textAreaContainer}
@@ -110,6 +138,11 @@ export default function EditPlaylistInfo() {
           />
           비공개
         </label>
+
+        <div>
+          <button onClick={handleSave}>저장</button>
+          <button onClick={() => navigate(-1)}>취소</button>
+        </div>
       </div>
       <div className="nav-margin-bottom"></div>
     </>

--- a/src/routes/pages/EditPlaylistInfo.tsx
+++ b/src/routes/pages/EditPlaylistInfo.tsx
@@ -151,10 +151,6 @@ export default function EditPlaylistInfo() {
           />
           비공개
         </label>
-
-        <div>
-          <button onClick={handleEdit}>저장</button>
-        </div>
       </div>
       <div className="nav-margin-bottom"></div>
     </>

--- a/src/routes/pages/EditPlaylistInfo.tsx
+++ b/src/routes/pages/EditPlaylistInfo.tsx
@@ -11,6 +11,9 @@ export default function EditPlaylistInfo() {
   const setTitle = useHeaderStore(state => state.setTitle)
   const location = useLocation() // playlist 데이터를 받기 위함
   const navigate = useNavigate()
+  const setHandleClickRightButton = useHeaderStore(
+    state => state.setHandleClickRightButton
+  )
 
   // location에서 playlist 데이터 가져오기
   const playlist = location.state?.playlist as Playlist | undefined
@@ -27,6 +30,31 @@ export default function EditPlaylistInfo() {
     setIsPublic(playlist.isPublic)
     setSelectedCategories(playlist.categories || ['전체'])
   }, [playlist, navigate])
+
+  const handleEdit = async () => {
+    if (!playlist) {
+      return
+    }
+
+    const updatedPlaylist = {
+      ...playlist,
+      title: videoTitle,
+      description: videoDescription,
+      isPublic,
+      categories: selectedCategories
+    }
+
+    try {
+      await editPlaylist.mutate(updatedPlaylist)
+      navigate(-1)
+    } catch (error) {
+      console.error('Error saving playlist:', error)
+    }
+  }
+
+  useEffect(() => {
+    setHandleClickRightButton(handleEdit)
+  }, [handleEdit, setHandleClickRightButton])
 
   const [videoTitle, setVideoTitle] = useState('')
   const [videoDescription, setVideoDescription] = useState('')
@@ -54,26 +82,6 @@ export default function EditPlaylistInfo() {
       categories = ['전체', ...categories]
     }
     setSelectedCategories(categories)
-  }
-
-  const handleEdit = async () => {
-    // 데이터 저장 로직 구현 (예: Firebase 업데이트)
-    try {
-      if (playlist) {
-        editPlaylist.mutate(playlist)
-      }
-      console.log({
-        title: videoTitle,
-        description: videoDescription,
-        isPublic,
-        categories: selectedCategories
-      })
-
-      // 저장 후 페이지 이동 (리다이렉션)
-      navigate(-1) // 이전 페이지로 돌아가기
-    } catch (error) {
-      console.error('Error saving playlist:', error)
-    }
   }
 
   const editPlaylist = useEditPlaylistInfo()

--- a/src/stores/header.ts
+++ b/src/stores/header.ts
@@ -1,14 +1,17 @@
 import { create } from 'zustand'
 import { combine } from 'zustand/middleware'
-
 export const useHeaderStore = create(
   combine(
     {
-      title: 'MAZI'
+      title: 'MAZI',
+      handleClickRightButton: () => {}
     },
     set => ({
       setTitle(title: string) {
         set({ title })
+      },
+      setHandleClickRightButton(handler: () => void) {
+        set({ handleClickRightButton: handler })
       }
     })
   )


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

EditplaylistInfo 정보 수정 페이지 기능 구현

## 📋 작업 내용

header store로 상태관리
수정/삭제 페이지 라우팅 연결
수정 페이지 들어갔을 때 기존 데이터 저장되어 있도록 수정
수정/삭제 페이지 헤더 경로 수정
useEditPlaylistInfo 훅 생성 및 파이어베이스 연결
정보 수정 후 저장하면 home, myplaylist 등에 반영

## 🔧 변경 사항

header store로 상태관리
수정/삭제 페이지 라우팅 연결
수정 페이지 들어갔을 때 기존 데이터 저장되어 있도록 수정
수정/삭제 페이지 헤더 경로 수정
useEditPlaylistInfo 훅 생성 및 파이어베이스 연결
정보 수정 후 저장하면 home, myplaylist 등에 반영

## 📸 스크린샷 (선택 사항)

![Uploading Screen Recording 2024-09-24 at 11.38.26 PM.gif…]()

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
