### PR TITLE
[Feature] 파이어베이스 Likes 데이터 저장하고 해제하기 #118

### DIFF
--- a/src/api/likes.ts
+++ b/src/api/likes.ts
@@ -1,0 +1,59 @@
+import { db } from '@/api/firebaseApp'
+import { doc, getDoc, updateDoc, setDoc, deleteDoc } from 'firebase/firestore'
+
+export const fetchLikes = async (playlistId: string) => {
+  const docRef = doc(db, 'Likes', playlistId)
+  const docSnap = await getDoc(docRef)
+
+  if (docSnap.exists()) {
+    const data = docSnap.data()
+    return {
+      likeCount: Number(data.likeCount) || 0,
+      userLikes: data.userLikes || {}
+    }
+  } else {
+    return { likeCount: 0, userLikes: {} }
+  }
+}
+
+export const updateLikes = async (
+  playlistId: string,
+  userId: string,
+  isLiked: boolean
+) => {
+  const docRef = doc(db, 'Likes', playlistId)
+
+  const docSnap = await getDoc(docRef)
+  let newLikeCount
+
+  if (docSnap.exists()) {
+    const currentData = docSnap.data()
+
+    if (isLiked) {
+      newLikeCount = (currentData.likeCount || 0) + 1
+      await updateDoc(docRef, {
+        [`userLikes.${userId}`]: true,
+        likeCount: newLikeCount
+      })
+    } else {
+      newLikeCount = Math.max(0, (currentData.likeCount || 0) - 1)
+      await updateDoc(docRef, {
+        [`userLikes.${userId}`]: null
+      })
+
+      if (newLikeCount > 0) {
+        await updateDoc(docRef, {
+          likeCount: newLikeCount
+        })
+      } else {
+        await deleteDoc(docRef)
+      }
+    }
+  } else {
+    newLikeCount = isLiked ? 1 : 0
+    await setDoc(docRef, {
+      likeCount: newLikeCount,
+      userLikes: { [userId]: isLiked }
+    })
+  }
+}

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -26,7 +26,7 @@ export default function Playlist({
     hideToast
   } = usePlaylistData(playlist)
 
-  const { isLikeFilled, handleLikeClick } = useLikeData(playlist.id)
+  const { isLikeFilled, handleLikeClick, likeCount } = useLikeData(playlist.id)
   const { extractVideoId } = useExtractVideoId()
 
   return (
@@ -69,6 +69,7 @@ export default function Playlist({
               onClick={handleLikeClick}
             />
           )}
+          <span css={likeCountStyle}>{likeCount}</span>
           <div
             css={commentContainerStyle}
             onClick={() => navigate(`/playlist-details/${playlist?.id}`)}>
@@ -136,6 +137,12 @@ const profileImageStyle = css`
   object-fit: cover;
   background-color: ${theme.colors.lightGrey};
 `
+const likeCountStyle = css`
+  font-size: ${theme.fontSize.lg};
+  margin-left: 10px;
+  color: ${theme.colors.charcoalGrey};
+`
+
 const emptyHeartIconStyle = css`
   font-size: 24px;
   margin-right: 30px;

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -11,9 +11,11 @@ import { css } from '@emotion/react'
 import { FaRegBookmark, FaBookmark } from 'react-icons/fa6'
 
 export default function Playlist({
-  playlist
+  playlist,
+  userId
 }: {
   playlist: Playlist | undefined
+  userId: string
 }) {
   const navigate = useNavigate()
   const {
@@ -25,8 +27,10 @@ export default function Playlist({
     isToastVisible,
     hideToast
   } = usePlaylistData(playlist)
-
-  const { isLikeFilled, handleLikeClick, likeCount } = useLikeData(playlist.id)
+  const { isLikeFilled, handleLikeClick, likeCount } = useLikeData(
+    playlist.id,
+    userId
+  )
   const { extractVideoId } = useExtractVideoId()
 
   return (
@@ -58,18 +62,21 @@ export default function Playlist({
 
       <div css={footerStyle}>
         <div css={iconsStyle}>
-          {isLikeFilled ? (
-            <VscHeartFilled
-              css={filledHeartIconStyle}
-              onClick={handleLikeClick}
-            />
-          ) : (
-            <CgHeart
-              css={emptyHeartIconStyle}
-              onClick={handleLikeClick}
-            />
-          )}
-          <span css={likeCountStyle}>{likeCount}</span>
+          <div css={likeContainerStyle}>
+            {isLikeFilled ? (
+              <VscHeartFilled
+                css={filledHeartIconStyle}
+                onClick={handleLikeClick}
+              />
+            ) : (
+              <CgHeart
+                css={emptyHeartIconStyle}
+                onClick={handleLikeClick}
+              />
+            )}
+            <span css={likeCountStyle}>{likeCount}</span>
+          </div>
+
           <div
             css={commentContainerStyle}
             onClick={() => navigate(`/playlist-details/${playlist?.id}`)}>
@@ -137,15 +144,10 @@ const profileImageStyle = css`
   object-fit: cover;
   background-color: ${theme.colors.lightGrey};
 `
-const likeCountStyle = css`
-  font-size: ${theme.fontSize.lg};
-  margin-left: 10px;
-  color: ${theme.colors.charcoalGrey};
-`
 
 const emptyHeartIconStyle = css`
   font-size: 24px;
-  margin-right: 30px;
+  margin-right: 10px;
   color: ${theme.colors.charcoalGrey};
   cursor: pointer;
   transition:
@@ -154,26 +156,36 @@ const emptyHeartIconStyle = css`
 `
 const filledHeartIconStyle = css`
   font-size: 24px;
-  margin-right: 30px;
+  margin-right: 10px;
   color: ${theme.colors.red};
   cursor: pointer;
   transition:
     color 0.9s ease,
     transform 0.9s ease;
 `
+const likeContainerStyle = css`
+  display: flex;
+  align-items: center;
+`
+const likeCountStyle = css`
+  font-size: ${theme.fontSize.md};
+  color: ${theme.colors.charcoalGrey};
+  margin-right: 10px;
+`
+
 const commentContainerStyle = css`
   display: flex;
   align-items: center;
   color: ${theme.colors.charcoalGrey};
   cursor: pointer;
-  margin-right: 30px;
+  margin-right: 10px;
 `
 const commentIconStyle = css`
   font-size: 24px;
   margin-right: 7px;
 `
 const commentCountStyle = css`
-  font-size: ${theme.fontSize.xl};
+  font-size: ${theme.fontSize.md};
 `
 const bookmarkIconStyle = css`
   font-size: ${theme.fontSize.xl};

--- a/src/hooks/useDeletePlaylist.ts
+++ b/src/hooks/useDeletePlaylist.ts
@@ -28,7 +28,7 @@ export const useDeletePlaylist = () => {
       }
     },
     onSuccess() {
-      queryClient.invalidateQueries({ queryKey: ['playlists'] })
+      queryClient.invalidateQueries({ queryKey: ['Playlists'] })
     }
   })
 }

--- a/src/hooks/useLikeData.ts
+++ b/src/hooks/useLikeData.ts
@@ -4,6 +4,7 @@ import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore'
 
 export const useLikeData = (playlistId: string) => {
   const [isLikeFilled, setIsLikeFilled] = useState(false)
+  const [likeCount, setLikeCount] = useState(0)
 
   useEffect(() => {
     const fetchLikeStatus = async () => {
@@ -20,6 +21,8 @@ export const useLikeData = (playlistId: string) => {
 
   const handleLikeClick = async () => {
     const docRef = doc(db, 'Likes', playlistId)
+    setIsLikeFilled(prev => !prev)
+    setLikeCount(prevCount => (isLikeFilled ? prevCount - 1 : prevCount + 1))
 
     if (isLikeFilled) {
       await updateDoc(docRef, { isLikeFilled: false })
@@ -32,6 +35,7 @@ export const useLikeData = (playlistId: string) => {
 
   return {
     isLikeFilled,
-    handleLikeClick
+    handleLikeClick,
+    likeCount
   }
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

파이어베이스에서 Likes 데이터를 불러오고 새로고침을 해도 데이터가 변하지 않게 했습니다.
`{likeCount}`로 숫자를 불러오고 해제했을시 DB에서 사라지는 함수를 추가했습니다.

## 📋 작업 내용

- Playlist.tsx 컴포넌트에서 좋아요 데이터 불러오기, 저장하기, 해제하기
- api 와 hook 분리

## 🔧 변경 사항

- likes.ts 생성
- useLikeData.ts 수정

## 📸 스크린샷 
![스크린샷 2024-09-25 오전 2 23 24](https://github.com/user-attachments/assets/87f2d529-5152-4de4-a29f-45b6c6567151)

