### PR TITLE
[Feature] 홈페이지 데이터 최신순 불러오기와 댓글 숫자데이터 연결 #141

### DIFF
--- a/src/components/common/SplashScreen.tsx
+++ b/src/components/common/SplashScreen.tsx
@@ -6,30 +6,6 @@ import { css } from '@emotion/react'
 import whiteLogo from '@/assets/whiteLogo.png'
 import backgroundImage from '@/assets/background.png'
 
-const containerStyle = css`
-  background-image: url(${backgroundImage});
-  background-size: 430px 990px;
-  background-position: center;
-  background-color: white;
-  background-repeat: no-repeat;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 430px;
-  height: 990px;
-  display: flex;
-  overflow: hidden;
-  justify-content: center;
-  align-items: center;
-  z-index: 3;
-`
-const logoStyle = css`
-  height: 60px;
-  width: 200px;
-  text-align: center;
-  z-index: 4;
-`
-
 export default function App() {
   const [isSplash, setIsSplash] = useState(true)
   const navigate = useNavigate()
@@ -59,3 +35,27 @@ export default function App() {
     </>
   )
 }
+
+const containerStyle = css`
+  background-image: url(${backgroundImage});
+  background-size: 430px 990px;
+  background-position: center;
+  background-color: white;
+  background-repeat: no-repeat;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  overflow: hidden;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+`
+const logoStyle = css`
+  height: 60px;
+  width: 200px;
+  text-align: center;
+  z-index: 2;
+`

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -7,6 +7,7 @@ import Toast from '@/components/common/Toast'
 import { usePlaylistData } from '@/hooks/useFetchPlaylistData'
 import { useLikeData } from '@/hooks/useLikeData'
 import { useExtractVideoId } from '@/hooks/useExtractVideoId'
+import { useFetchComments } from '@/hooks/useFetchComments'
 import { css } from '@emotion/react'
 import { FaRegBookmark, FaBookmark } from 'react-icons/fa6'
 
@@ -18,7 +19,6 @@ export default function Playlist({
 }) {
   const navigate = useNavigate()
   const {
-    commentCount,
     userData,
     isBookmarked,
     handleBookmark,
@@ -29,6 +29,7 @@ export default function Playlist({
 
   const { isLikeFilled, handleLikeClick, likeCount } = useLikeData(playlist.id)
   const { extractVideoId } = useExtractVideoId()
+  const { data: comments } = useFetchComments(playlist?.id)
 
   return (
     <div css={playlistStyle}>
@@ -78,7 +79,7 @@ export default function Playlist({
             css={commentContainerStyle}
             onClick={() => navigate(`/playlist-details/${playlist?.id}`)}>
             <CgComment css={commentIconStyle} />
-            <span css={commentCountStyle}>{commentCount}</span>
+            <span css={commentCountStyle}>{comments?.length || 0}</span>
           </div>
           {handleBookmark &&
             (isBookmarked ? (
@@ -133,6 +134,7 @@ const footerStyle = css`
 `
 const iconsStyle = css`
   display: flex;
+  margin-top: 10px;
   margin-bottom: 10px;
 `
 const profileImageStyle = css`
@@ -206,6 +208,7 @@ const titleStyle = css`
   font-size: ${theme.fontSize.lg};
   color: ${theme.colors.black};
   margin: 0;
+  margin-top: 5px;
   margin-bottom: 10px;
 `
 const timeRecordStyle = css`

--- a/src/hooks/useFetchComments.ts
+++ b/src/hooks/useFetchComments.ts
@@ -13,30 +13,28 @@ export interface Comment {
   user: User
   content: string
   createdAt: string
-  playlistid: string
+  playlistId: string
   userId: string
 }
 
-export const useFetchComments = (playlistid: string) => {
+export const useFetchComments = (playlistId: string) => {
   return useQuery<Comment[]>({
-    queryKey: ['comments', playlistid],
+    queryKey: ['comments', playlistId],
     queryFn: async () => {
       const db = getFirestore()
       const coll = collection(db, 'Comments')
-      console.log('playlistid::', playlistid)
       const querySnapshot = await getDocs(
-        query(coll, where('playlistId', '==', playlistid))
+        query(coll, where('playlistId', '==', playlistId))
       )
       return querySnapshot.docs.map(doc => {
-        console.log(doc)
+        const data = doc.data() as Omit<Comment, 'id'>
         return {
           id: doc.id,
-          ...doc.data()
+          ...data
         }
-      }) as Comment[]
+      })
     },
     select(data) {
-      console.log('select::', data)
       return data.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
     }
   })

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -15,16 +15,18 @@ export default function Home() {
   const location = useLocation()
   const [showToast, setShowToast] = useState(false)
   const navigate = useNavigate()
-  const [selectedCategories, setSelectedCategories] = useState<string[]>(['전체'])
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([
+    '전체'
+  ])
   const [displayName, setDisplayName] = useState<string | null>(null)
 
   useEffect(() => {
-    setTitle('Home');
+    setTitle('Home')
 
-    const auth = getAuth();
-    const user = auth.currentUser;
+    const auth = getAuth()
+    const user = auth.currentUser
     if (user) {
-      setDisplayName(user.displayName);
+      setDisplayName(user.displayName)
     }
   }, [setTitle])
 
@@ -52,14 +54,16 @@ export default function Home() {
     }
   }, [selectedCategories])
 
-  const filteredData =
-    selectedCategories.length > 0
-      ? data?.filter(
-          pl =>
-            Array.isArray(pl.categories) &&
-            selectedCategories.some(cat => pl.categories.includes(cat))
-        )
-      : data
+  const filteredAndSortedData: PlaylistType[] | undefined = data
+    ?.filter(
+      (pl): pl is PlaylistType =>
+        Array.isArray(pl.categories) &&
+        selectedCategories.some(cat => pl.categories.includes(cat))
+    )
+    ?.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
 
   return (
     <>
@@ -68,10 +72,10 @@ export default function Home() {
         selectedCategories={selectedCategories}
         onSelectCategory={setSelectedCategories}
       />
-
-      {isLoading && <div>데이터를 가져오고 있는 중...</div>}
-      {filteredData &&
-        filteredData.map(pl => (
+      {/* 
+      {isLoading && <div>데이터 불러오기</div>} */}
+      {filteredAndSortedData &&
+        filteredAndSortedData.map(pl => (
           <Playlist
             key={pl.id}
             playlist={pl}

--- a/src/routes/pages/SignIn.tsx
+++ b/src/routes/pages/SignIn.tsx
@@ -7,6 +7,46 @@ import { css } from '@emotion/react'
 import LongButton from '@/components/common/LongButton'
 import theme from '@/styles/theme'
 
+export default function SignIn() {
+  const navigate = useNavigate()
+
+  async function handleSignIn() {
+    try {
+      await signInWithGoogleAndCreateUser()
+      navigate('/')
+    } catch (error) {
+      console.error('로그인 실패:', error)
+    }
+  }
+
+  return (
+    <div css={containerStyle}>
+      <div css={contentStyle}>
+        <img
+          css={logoStyle}
+          src={logo}
+          alt="Logo"
+        />
+      </div>
+
+      <div css={buttonStyle}>
+        <LongButton onClick={handleSignIn}>
+          <img
+            src={googleLogo}
+            alt="Google Logo"
+            style={{ width: '20px', height: '20px' }}
+          />
+          Google 로그인
+        </LongButton>
+      </div>
+
+      <div>
+        <p css={signInText}>ⓒ MAZI. All Rights Reserved.</p>
+      </div>
+    </div>
+  )
+}
+
 const containerStyle = css`
   height: 100vh;
   width: 100%;
@@ -65,43 +105,3 @@ const signInText = css`
   transform: translate(-50%, -50%);
   font-size: ${theme.fontSize.sm};
 `
-export default function SignIn() {
-  const navigate = useNavigate()
-
-  async function handleSignIn() {
-    try {
-      await signInWithGoogleAndCreateUser()
-      navigate('/')
-    } catch (error) {
-      console.error('로그인 실패:', error)
-      // 에러 처리 로직 추가
-    }
-  }
-
-  return (
-    <div css={containerStyle}>
-      <div css={contentStyle}>
-        <img
-          css={logoStyle}
-          src={logo}
-          alt="Logo"
-        />
-      </div>
-
-      <div css={buttonStyle}>
-        <LongButton onClick={handleSignIn}>
-          <img
-            src={googleLogo}
-            alt="Google Logo"
-            style={{ width: '20px', height: '20px' }}
-          />
-          Google 로그인
-        </LongButton>
-      </div>
-
-      <div>
-        <p css={signInText}>ⓒ MAZI. All Rights Reserved.</p>
-      </div>
-    </div>
-  )
-}

--- a/src/stores/header.ts
+++ b/src/stores/header.ts
@@ -3,7 +3,7 @@ import { combine } from 'zustand/middleware'
 export const useHeaderStore = create(
   combine(
     {
-      title: 'MAZI',
+      title: '',
       handleClickRightButton: () => {}
     },
     set => ({


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

홈페이지에서 데이터를 최신순으로 불러오고 댓글 아이콘 옆에 숫자 데이터를 연결시켰습니다.
데이터를 최신순과 카테고리별로 확인 가능하며, 사용자들이 남긴 댓글의 숫자를 볼수있습니다.
스플래시 스크린의 레이아웃을 센터로 변경했습니다.

## 📋 작업 내용

- 홈페이지 플레이리스트 최신순
- 댓글 숫자데이터 연결
- 스플래시 스크린 레이아웃 조절

## 🔧 변경 사항

- 스플래시 스크린 CSS 변경
- 데이터 로딩 중 삭제
- 헤더에 중복으로 뜨던 MAZI 문구 삭제
- 플레이리스트 컴포넌트 CSS 변경

## 📸 스크린샷 
![스크린샷 2024-09-25 오전 4 41 50](https://github.com/user-attachments/assets/0b6b0384-c20c-45ae-9195-525dcea6064a)

