### PR TITLE
[Bug] 무한스크롤 비공개 필터 설정 #163

### DIFF
--- a/src/api/playlistApi.tsx
+++ b/src/api/playlistApi.tsx
@@ -12,6 +12,7 @@ const ITEMS_PER_PAGE = 10
 
 export const fetchPlaylists = async (lastVisible: any) => {
   const playlistsRef = collection(db, 'Playlists')
+
   let q = query(playlistsRef, orderBy('createdAt'), limit(ITEMS_PER_PAGE))
 
   if (lastVisible) {

--- a/src/components/infiniteScroll/InfiniteScroll.tsx
+++ b/src/components/infiniteScroll/InfiniteScroll.tsx
@@ -2,13 +2,13 @@ import { useInfiniteScroll } from '../../hooks/useInfiniteScroll'
 import Playlist from '@/components/playlist/Playlist'
 
 const PlaylistInfiniteScroll = () => {
-  const { playlists, loading } = useInfiniteScroll()
+  const { playlists, loading } = useInfiniteScroll(true)
 
   return (
     <div>
       {playlists.map(playlist => (
         <Playlist
-          key={playlist.userId}
+          key={playlist.id}
           playlist={playlist}
         />
       ))}

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react'
 import { fetchPlaylists } from '../api/playlistApi'
 
-export const useInfiniteScroll = () => {
+interface Playlist {
+  id: string
+  title: string
+  isPublic: boolean
+}
+
+export const useInfiniteScroll = (isPublic: boolean) => {
   const [playlists, setPlaylists] = useState<Playlist[]>([])
   const [lastVisible, setLastVisible] = useState<any>(null)
   const [loading, setLoading] = useState(false)
@@ -11,11 +17,16 @@ export const useInfiniteScroll = () => {
 
   const loadPlaylists = async () => {
     if (totalFetched >= MAX_PLAYLISTS) return
-    setLoading(true)
-    const { newPlaylists, lastVisible: newLastVisible } =
-      await fetchPlaylists(lastVisible)
 
-    setPlaylists(prevPlaylists => [...prevPlaylists, ...newPlaylists])
+    setLoading(true)
+    const { newPlaylists, lastVisible: newLastVisible } = await fetchPlaylists(
+      lastVisible,
+      isPublic
+    )
+
+    const filteredPlaylists = newPlaylists.filter(playlist => playlist.isPublic)
+
+    setPlaylists(prevPlaylists => [...prevPlaylists, ...filteredPlaylists])
     setLastVisible(newLastVisible)
     setTotalFetched(prevCount => prevCount + newPlaylists.length)
     setLoading(false)
@@ -37,8 +48,6 @@ export const useInfiniteScroll = () => {
 
     window.addEventListener('scroll', handleScroll)
     return () => window.removeEventListener('scroll', handleScroll)
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastVisible, loading, totalFetched])
 
   return { playlists, loading }

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -65,8 +65,7 @@ export default function Home() {
         selectedCategories={selectedCategories}
         onSelectCategory={setSelectedCategories}
       />
-      {/* 
-      {isLoading && <div>데이터 불러오기</div>} */}
+
       {filteredAndSortedData &&
         filteredAndSortedData.map(pl => (
           <Playlist


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

무한스크롤시 홈에서 보여지던 비공개 데이터들을 숨김처리 했습니다.

## 📋 작업 내용

무한스크롤 비공개 데이터 숨김처리

## 🔧 변경 사항

- useInfiniteScroll에서 isPublic (true) 값만 불러오기