### PR TITLE
[Feature] 프로필 사진 크기 조정, 추가페이지 완료 후 마이플리로 이동 및 토스트 띄움, 자잘한 에러 수정 #176

### DIFF
--- a/src/components/layouts/headers/TheHeader.tsx
+++ b/src/components/layouts/headers/TheHeader.tsx
@@ -16,7 +16,7 @@ export default function TheHeader({ onOpenModal }: TheHeaderProps) {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const { isDone, savePlaylist, isPublic } = useAddPlaylistStore()
+  const { isDone, savePlaylist } = useAddPlaylistStore()
   const { saveProfile } = useProfileStore()
 
   const isAddPlaylist = location.pathname === '/add-playlist'
@@ -36,11 +36,12 @@ export default function TheHeader({ onOpenModal }: TheHeaderProps) {
   const handleComplete = async () => {
     try {
       await savePlaylist()
-      navigate(isPublic ? '/' : '/')
+      navigate('/my-playlist', { state: { showToast: true } })
     } catch (error) {
       console.error('Failed to save:', error)
     }
   }
+  
 
   return (
     <header css={headerStyle}>
@@ -58,8 +59,7 @@ export default function TheHeader({ onOpenModal }: TheHeaderProps) {
       {isAddPlaylist && (
         <button
           css={successBtn(isDone)}
-          onClick={isDone ? handleComplete : undefined}
-          disabled={!isDone}
+          onClick={handleComplete}
         >
           완료
         </button>

--- a/src/components/playlist/Playlist.tsx
+++ b/src/components/playlist/Playlist.tsx
@@ -11,11 +11,23 @@ import { useFetchComments } from '@/hooks/useFetchComments'
 import { css } from '@emotion/react'
 import { FaRegBookmark, FaBookmark } from 'react-icons/fa6'
 
+export type PlaylistType = {
+  id: string
+  title: string
+  urls: string[]
+  createdAt: string
+  userId: string
+  categories: string[]
+  isPublic: boolean
+  description: string
+}
+
 export default function Playlist({
   playlist
 }: {
-  playlist: Playlist | undefined
-  userId: string
+  playlist: PlaylistType
+  userId?: string
+  onClick: () => void
 }) {
   const navigate = useNavigate()
   const {

--- a/src/routes/pages/EditProfile.tsx
+++ b/src/routes/pages/EditProfile.tsx
@@ -158,23 +158,24 @@ const pageStyle = css`
 
 const profileContainerStyle = css`
   position: relative;
-  width: 130px;
   margin-top: 40px;
 `;
 
 const profileStyle = css`
-  width: 100%;
+  height:150px;
+  width: 150px;
   border-radius: 50%;
+  object-fit: cover;
   cursor: pointer; 
 `;
 
 const iconStyle = css`
   position: absolute;
-  bottom: 0;
-  right: 0;
+  bottom: 0px;
+  right: 8px;
   background-color: rgba(0, 0, 0, 0.6);
   border-radius: 50%;
-  padding: 6px;
+  padding: 5px;
   cursor: pointer;
   color: white;
 `;

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -1,19 +1,13 @@
 import { Category } from '@/components/common/Category'
-import Playlist, {
-  Playlist as PlaylistType
-} from '@/components/playlist/Playlist'
+import Playlist, { PlaylistType } from '@/components/playlist/Playlist';
 import { useHeaderStore } from '@/stores/header'
 import { useFetchPlaylists } from '@/hooks/useFetchPlaylists'
 import { useEffect, useState } from 'react'
-import { useLocation } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
-import Toast from '@/components/common/Toast'
 import InfiniteScroll from '@/components/infiniteScroll/InfiniteScroll'
 
 export default function Home() {
   const setTitle = useHeaderStore(state => state.setTitle)
-  const location = useLocation()
-  const [showToast, setShowToast] = useState(false)
   const navigate = useNavigate()
   const [selectedCategories, setSelectedCategories] = useState<string[]>([
     '전체'
@@ -25,21 +19,13 @@ export default function Home() {
 
   const { data } = useFetchPlaylists(false)
 
-  const handlePlaylistClick = (playlist: PlaylistType) => {
-    navigate(`/playlist/${playlist.id}`, { state: { playlist } })
-  }
-
-  useEffect(() => {
-    if (location.state?.showToast) {
-      setShowToast(true)
-
-      setTimeout(() => {
-        setShowToast(false)
-        const newState = { ...location.state, showToast: false }
-        window.history.replaceState(newState, document.title)
-      }, 3000)
+  const handlePlaylistClick = (playlist: PlaylistType | undefined | null) => {
+    if (!playlist) {
+      return;
     }
-  }, [location.state])
+    navigate(`/playlist/${playlist.id}`, { state: { playlist } });
+  };
+  
 
   useEffect(() => {
     if (selectedCategories.length === 0) {
@@ -48,15 +34,18 @@ export default function Home() {
   }, [selectedCategories])
 
   const filteredAndSortedData: PlaylistType[] | undefined = data
-    ?.filter(
-      (pl): pl is PlaylistType =>
-        Array.isArray(pl.categories) &&
-        selectedCategories.some(cat => pl.categories.includes(cat))
-    )
-    ?.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    )
+  ?.filter((pl): pl is PlaylistType => {
+    return (
+      typeof pl.id === 'string' &&
+      typeof pl.title === 'string' &&
+      Array.isArray(pl.urls) &&
+      typeof pl.createdAt === 'string' &&
+      typeof pl.userId === 'string' &&
+      Array.isArray(pl.categories) &&
+      selectedCategories.some(cat => pl.categories.includes(cat))
+    );
+  })
+  ?.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
   return (
     <>
@@ -73,16 +62,8 @@ export default function Home() {
             playlist={pl}
             onClick={() => handlePlaylistClick(pl)}
           />
-        ))}
-      {showToast && (
-        <Toast
-          message="플레이리스트에 추가 되었습니다!"
-          isVisible={showToast}
-          onHide={() => setShowToast(false)}
-        />
-      )}
-
-      <div className="nav-margin-bottom"></div>
+          ))}
+            <div className="nav-margin-bottom"></div>
       <InfiniteScroll />
     </>
   )

--- a/src/routes/pages/Profile.tsx
+++ b/src/routes/pages/Profile.tsx
@@ -84,9 +84,11 @@ const pageStyle = css`
   gap: 10px;
 `
 const profileStyle = css`
-  width: 130px;
+  height:150px;
+  width: 150px;
   margin-top: 40px;
   border-radius: 50%;
+  object-fit:cover;
 `
 const textStyle = css`
   margin-top: 3rem;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

프로필 사진 크기 조정, 추가페이지 완료 후 마이플리로 이동 및 토스트 띄움, 자잘한 에러 수정

## 📋 작업 내용

프로필 사진 크기 조정, 추가페이지 완료 후 마이플리로 이동 및 토스트 띄움, 자잘한 에러 수정

## 🔧 변경 사항

추가페이지 완료 후 마이플리로 이동 및 토스트 띄움, 자잘한 에러 수정
에러는 보통 타입에러여서 Playlists 에서 타입 선언 후 내보내기 해줬습니다.
내플레이리스트 페이지의 카테고리 기능을 넣었습니다
프로필 사진 크기 고정해주고 cover 해줬습니다

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
