### PR TITLE
[feature] 디테일 페이지 프로필 사진과 유저이름 구현, 댓글과 동영상 삭제 바텀시트에 motion 효과 구현 및 수정

### DIFF
--- a/src/components/Comments/CommentsModal.tsx
+++ b/src/components/Comments/CommentsModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useCreateComment } from '@/hooks/useCreateComment'
 import { useDeleteComment } from '@/hooks/useDeleteComment'
 import type { Comment } from '@/hooks/useFetchComments'
@@ -45,81 +46,136 @@ const CommentsModal: React.FC<CommentsModalProps> = ({
     deleteComment({ commentId, playlistId })
   }
 
+  // 페이지 애니메이션 효과
+  const pageEffect = {
+    hidden: {
+      opacity: 0,
+      y: '100vh'
+    },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.5
+      }
+    },
+    exit: {
+      opacity: 0,
+      y: '100vh',
+      transition: {
+        duration: 1
+      }
+    }
+  }
+
+  // 배경 애니메이션 효과
+  const overlayEffect = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 0.5,
+      transition: { duration: 0.3 }
+    },
+    exit: {
+      opacity: 0,
+      transition: { duration: 0.6 }
+    }
+  }
+
   return (
-    <div css={modalOverlayStyle}>
-      <div css={modalContainerStyle}>
-        <div css={headerContainerStyle}>
-          <CgClose
-            onClick={onClose}
-            css={closeButtonStyle}
-          />
-          <h1 css={modalTitleStyle}>댓글</h1>
-        </div>
-        <hr css={dividerStyle} />
-        <div css={commentsContainerStyle}>
-          {comments.length === 0 ? (
-            <p css={noCommentsStyle}>
-              아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
-            </p>
-          ) : (
-            comments.map(comment => (
-              <div
-                key={comment.id}
-                css={commentItemStyle}>
-                <img
-                  src={comment.user.photoURL || '/default-profile.png'}
-                  alt={comment.user.displayName || 'User'}
-                  css={profileImageStyle}
-                />
-                <span css={usernameStyle}>{comment.user.displayName}</span>
-
-                <div css={commentContentStyle}>
-                  <p>{comment.content}</p>
-                </div>
-
-                {comment.user.uid === userId && (
-                  <CgTrash
-                    onClick={() => handleCommentDelete(comment.id)}
-                    css={deleteButtonStyle}
+    <AnimatePresence>
+      {/* 어두운 배경 */}
+      <motion.div
+        className="modalOverlay"
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        variants={overlayEffect}
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          zIndex: 2
+        }}
+      />
+      {/* 모달 */}
+      <motion.div
+        className="commentsModal"
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        variants={pageEffect}
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          zIndex: 3
+        }}>
+        <div css={modalContainerStyle}>
+          <div css={headerContainerStyle}>
+            <CgClose
+              onClick={onClose}
+              css={closeButtonStyle}
+            />
+            <h1 css={modalTitleStyle}>댓글</h1>
+          </div>
+          <hr css={dividerStyle} />
+          <div css={commentsContainerStyle}>
+            {comments.length === 0 ? (
+              <p css={noCommentsStyle}>
+                아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
+              </p>
+            ) : (
+              comments.map(comment => (
+                <div
+                  key={comment.id}
+                  css={commentItemStyle}>
+                  <img
+                    src={comment.user.photoURL || '/default-profile.png'}
+                    alt={comment.user.displayName || 'User'}
+                    css={profileImageStyle}
                   />
-                )}
-              </div>
-            ))
-          )}
+                  <span css={usernameStyle}>{comment.user.displayName}</span>
+
+                  <div css={commentContentStyle}>
+                    <p>{comment.content}</p>
+                  </div>
+
+                  {comment.user.uid === userId && (
+                    <CgTrash
+                      onClick={() => handleCommentDelete(comment.id)}
+                      css={deleteButtonStyle}
+                    />
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+          <div css={inputContainerStyle}>
+            <input
+              type="text"
+              value={comment}
+              onChange={handleCommentChange}
+              placeholder="댓글을 입력해 주세요."
+              css={inputStyle}
+            />
+            <button
+              onClick={handleCommentSubmit}
+              css={submitButtonStyle}>
+              전송
+            </button>
+          </div>
         </div>
-        <div css={inputContainerStyle}>
-          <input
-            type="text"
-            value={comment}
-            onChange={handleCommentChange}
-            placeholder="댓글을 입력해 주세요."
-            css={inputStyle}
-          />
-          <button
-            onClick={handleCommentSubmit}
-            css={submitButtonStyle}>
-            전송
-          </button>
-        </div>
-      </div>
-    </div>
+      </motion.div>
+    </AnimatePresence>
   )
 }
 
 export default CommentsModal
-
-const modalOverlayStyle = css`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 3;
-`
 
 const modalContainerStyle = css`
   background: white;
@@ -136,7 +192,9 @@ const modalContainerStyle = css`
   left: 50%;
   transform: translateX(-50%);
   height: 100%;
+  z-index: 3;
 `
+
 const headerContainerStyle = css`
   display: flex;
   justify-content: space-between;
@@ -144,6 +202,7 @@ const headerContainerStyle = css`
   margin-bottom: 10px;
   margin-top: 10px;
 `
+
 const modalTitleStyle = css`
   font-size: ${theme.fontSize.lg};
   font-weight: ${theme.fontWeight.semiBold};
@@ -175,10 +234,9 @@ const commentContentStyle = css`
   flex: 1;
   display: block;
   padding-right: 40px;
-  text-align: left;pl
-
-
+  text-align: left;
 `
+
 const commentItemStyle = css`
   display: flex;
   align-items: center;
@@ -188,6 +246,9 @@ const commentItemStyle = css`
   align-items: center;
   gap: 15px;
   margin-top: 20px;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
 `
 
 const profileImageStyle = css`
@@ -249,12 +310,4 @@ const deleteButtonStyle = css`
   right: 0;
   width: 18px;
   height: 18px;
-  border: none;
-  background-color: transparent;
-  color: ${theme.colors.charcoalGrey};
-  cursor: pointer;
-
-  &:hover {
-    color: ${theme.colors.lightBlue};
-  }
 `

--- a/src/components/Comments/CommentsModal.tsx
+++ b/src/components/Comments/CommentsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useCreateComment } from '@/hooks/useCreateComment'
 import { useDeleteComment } from '@/hooks/useDeleteComment'
@@ -25,6 +25,7 @@ const CommentsModal: React.FC<CommentsModalProps> = ({
   userId
 }) => {
   const [comment, setComment] = useState('')
+  const [isVisible, setIsVisible] = useState(true)
   const { mutate: createComment } = useCreateComment()
   const { mutate: deleteComment } = useDeleteComment()
 
@@ -46,7 +47,11 @@ const CommentsModal: React.FC<CommentsModalProps> = ({
     deleteComment({ commentId, playlistId })
   }
 
-  // 페이지 애니메이션 효과
+  const handleClose = () => {
+    setIsVisible(false)
+    setTimeout(onClose, 500)
+  }
+
   const pageEffect = {
     hidden: {
       opacity: 0,
@@ -63,12 +68,11 @@ const CommentsModal: React.FC<CommentsModalProps> = ({
       opacity: 0,
       y: '100vh',
       transition: {
-        duration: 1
+        duration: 0.5
       }
     }
   }
 
-  // 배경 애니메이션 효과
   const overlayEffect = {
     hidden: { opacity: 0 },
     visible: {
@@ -77,100 +81,104 @@ const CommentsModal: React.FC<CommentsModalProps> = ({
     },
     exit: {
       opacity: 0,
-      transition: { duration: 0.6 }
+      transition: { duration: 0.3 }
     }
   }
 
   return (
     <AnimatePresence>
-      {/* 어두운 배경 */}
-      <motion.div
-        className="modalOverlay"
-        initial="hidden"
-        animate="visible"
-        exit="exit"
-        variants={overlayEffect}
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          zIndex: 2
-        }}
-      />
-      {/* 모달 */}
-      <motion.div
-        className="commentsModal"
-        initial="hidden"
-        animate="visible"
-        exit="exit"
-        variants={pageEffect}
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          zIndex: 3
-        }}>
-        <div css={modalContainerStyle}>
-          <div css={headerContainerStyle}>
-            <CgClose
-              onClick={onClose}
-              css={closeButtonStyle}
-            />
-            <h1 css={modalTitleStyle}>댓글</h1>
-          </div>
-          <hr css={dividerStyle} />
-          <div css={commentsContainerStyle}>
-            {comments.length === 0 ? (
-              <p css={noCommentsStyle}>
-                아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
-              </p>
-            ) : (
-              comments.map(comment => (
-                <div
-                  key={comment.id}
-                  css={commentItemStyle}>
-                  <img
-                    src={comment.user.photoURL || '/default-profile.png'}
-                    alt={comment.user.displayName || 'User'}
-                    css={profileImageStyle}
-                  />
-                  <span css={usernameStyle}>{comment.user.displayName}</span>
+      {isVisible && (
+        <>
+          <motion.div
+            className="modalOverlay"
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            variants={overlayEffect}
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(0, 0, 0, 0.5)',
+              zIndex: 2
+            }}
+          />
+          <motion.div
+            className="commentsModal"
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            variants={pageEffect}
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              zIndex: 3
+            }}>
+            <div css={modalContainerStyle}>
+              <div css={headerContainerStyle}>
+                <CgClose
+                  onClick={handleClose}
+                  css={closeButtonStyle}
+                />
+                <h1 css={modalTitleStyle}>댓글</h1>
+              </div>
+              <hr css={dividerStyle} />
+              <div css={commentsContainerStyle}>
+                {comments.length === 0 ? (
+                  <p css={noCommentsStyle}>
+                    아직 댓글이 없습니다. 첫 댓글을 남겨보세요.
+                  </p>
+                ) : (
+                  comments.map(comment => (
+                    <div
+                      key={comment.id}
+                      css={commentItemStyle}>
+                      <img
+                        src={comment.user.photoURL || '/default-profile.png'}
+                        alt={comment.user.displayName || 'User'}
+                        css={profileImageStyle}
+                      />
+                      <span css={usernameStyle}>
+                        {comment.user.displayName}
+                      </span>
 
-                  <div css={commentContentStyle}>
-                    <p>{comment.content}</p>
-                  </div>
+                      <div css={commentContentStyle}>
+                        <p>{comment.content}</p>
+                      </div>
 
-                  {comment.user.uid === userId && (
-                    <CgTrash
-                      onClick={() => handleCommentDelete(comment.id)}
-                      css={deleteButtonStyle}
-                    />
-                  )}
-                </div>
-              ))
-            )}
-          </div>
-          <div css={inputContainerStyle}>
-            <input
-              type="text"
-              value={comment}
-              onChange={handleCommentChange}
-              placeholder="댓글을 입력해 주세요."
-              css={inputStyle}
-            />
-            <button
-              onClick={handleCommentSubmit}
-              css={submitButtonStyle}>
-              전송
-            </button>
-          </div>
-        </div>
-      </motion.div>
+                      {comment.user.uid === userId && (
+                        <CgTrash
+                          onClick={() => handleCommentDelete(comment.id)}
+                          css={deleteButtonStyle}
+                        />
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+              <div css={inputContainerStyle}>
+                <input
+                  type="text"
+                  value={comment}
+                  onChange={handleCommentChange}
+                  placeholder="댓글을 입력해 주세요."
+                  css={inputStyle}
+                />
+                <button
+                  onClick={handleCommentSubmit}
+                  css={submitButtonStyle}>
+                  전송
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
     </AnimatePresence>
   )
 }

--- a/src/components/playlist/EditPlaylistModal.tsx
+++ b/src/components/playlist/EditPlaylistModal.tsx
@@ -16,21 +16,33 @@ const EditPlaylist = ({ closeEdit, playlist, videoUrl }: PlayListProps) => {
   const pageEffect = {
     hidden: {
       opacity: 0,
-      y: '100vh'
+      transform: 'translateY(100%)'
     },
     visible: {
       opacity: 1,
-      y: 0,
+      transform: 'translateY(0%)',
       transition: {
-        duration: 0.5
+        duration: 0.3
       }
     },
     exit: {
       opacity: 0,
-      y: '100vh',
+      transform: 'translateY(100%)',
       transition: {
-        duration: 1
+        duration: 0.3
       }
+    }
+  }
+
+  const overlayEffect = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 0.5, // 배경을 어둡게 설정
+      transition: { duration: 0.3 }
+    },
+    exit: {
+      opacity: 0,
+      transition: { duration: 0.3 }
     }
   }
 
@@ -41,7 +53,7 @@ const EditPlaylist = ({ closeEdit, playlist, videoUrl }: PlayListProps) => {
       console.log('삭제할 비디오 URL:', videoUrl)
       deleteVideo.mutate({
         playlist,
-        videoUrl
+        videoUrl: videoUrl ?? ''
       })
 
       closeEdit() // 모달 닫기
@@ -51,22 +63,40 @@ const EditPlaylist = ({ closeEdit, playlist, videoUrl }: PlayListProps) => {
   }
 
   return (
-    <motion.div
-      className="editPage"
-      initial="hidden"
-      animate="visible"
-      exit="exit"
-      variants={pageEffect}
-      style={{
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        width: '100%',
-        height: '200px',
-        zIndex: 3
-      }}>
-      <>
-        <div css={bgStyle}></div>
+    <>
+      {/* 어두운 배경 */}
+      <motion.div
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        variants={overlayEffect}
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          backgroundColor: 'rgba(0, 0, 0, 0.5)', // 어두운 배경 색상
+          zIndex: 2 // 모달 뒤에 어두운 배경이 오도록 설정
+        }}
+      />
+      {/* 모달 */}
+      <motion.div
+        className="editPage"
+        initial="hidden"
+        animate="visible"
+        exit="exit"
+        variants={pageEffect}
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: '27.8%',
+          transform: 'translateX(-50%)',
+          width: '430px',
+          maxWidth: '100%',
+          height: '200px',
+          zIndex: 3 // 모달은 배경 위에 표시되도록 설정
+        }}>
         <div css={EditModalContainerStyle}>
           <button
             css={cancelButtonStyle}
@@ -77,28 +107,16 @@ const EditPlaylist = ({ closeEdit, playlist, videoUrl }: PlayListProps) => {
             <LongButton onClick={handleDelete}>동영상 삭제</LongButton>
           </div>
         </div>
-      </>
-    </motion.div>
+      </motion.div>
+    </>
   )
 }
-// handleDelete(playlist)
 
 export default EditPlaylist
 
-const bgStyle = css`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
-  z-index: -1;
-  opacity: 0.8;
-`
-
 const EditModalContainerStyle = css`
   height: 100%;
-  width: 430px;
+  width: 100%;
   background-color: ${theme.colors.white};
   display: flex;
   flex-direction: column;
@@ -106,6 +124,7 @@ const EditModalContainerStyle = css`
   padding: 20px;
   align-items: center;
   justify-content: center;
+  box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.1);
 `
 
 const cancelButtonStyle = css`

--- a/src/components/playlist/PlaylistDetail.tsx
+++ b/src/components/playlist/PlaylistDetail.tsx
@@ -24,6 +24,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { useFetchPlaylistById } from '@/hooks/useFetchPlaylistById'
 import { useDeleteVideo } from '@/hooks/useDeleteVideo'
+import { useFetchUserId } from '@/hooks/useFetchUserId'
 
 dayjs.locale('ko')
 dayjs.extend(relativeTime)
@@ -73,6 +74,12 @@ export default function PlaylistDetail({
   const navigate = useNavigate()
   const { id } = useParams() // URL 파라미터에서 id 추출
   const { data: playlistData, isLoading, error } = useFetchPlaylistById(id) // 플레이리스트 데이터 가져오기
+  // playlistData.userId를 기반으로 해당 유저의 정보를 가져옴
+  const {
+    data: userData,
+    isLoading: isUserLoading,
+    error: userError
+  } = useFetchUserId(playlistData?.userId)
   const deleteVideo = useDeleteVideo()
 
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(false)
@@ -239,16 +246,16 @@ export default function PlaylistDetail({
       </div>
 
       <div css={sectionThreeContainer}>
-        {user && showComments && (
+        {userData && showComments && (
           <>
             <img
-              src={user.photoURL || ''}
-              alt={user.displayName || 'User'}
+              src={userData.photoURL || ''}
+              alt={userData.displayName || 'User'}
               width="50"
               height="50"
               css={profileImageStyle}
             />
-            <span>{user.displayName}</span>
+            <span>{userData.displayName}</span>
           </>
         )}
       </div>

--- a/src/hooks/useFetchUserId.ts
+++ b/src/hooks/useFetchUserId.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+import { getFirestore, doc, getDoc } from 'firebase/firestore'
+
+// User 정보 타입
+export interface User {
+  displayName: string
+  photoURL: string
+  uid: string
+}
+
+// userId로 해당 유저의 정보를 가져오는 훅
+export const useFetchUserId = (userId: string) => {
+  return useQuery<User>({
+    queryKey: ['User', userId], // 쿼리 키
+    queryFn: async () => {
+      const db = getFirestore()
+      const userDocRef = doc(db, 'Users', userId) // Users 컬렉션에서 userId로 문서 찾기
+      const userSnap = await getDoc(userDocRef)
+
+      if (!userSnap.exists()) {
+        throw new Error('사용자를 찾을 수 없습니다.')
+      }
+
+      return {
+        displayName: userSnap.data().displayName,
+        photoURL: userSnap.data().photoURL,
+        uid: userSnap.id
+      } as User
+    },
+    enabled: !!userId // userId가 있을 때만 쿼리 실행
+  })
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

디테일 페이지 프로필 사진과 유저이름 구현, 댓글과 동영상 삭제 바텀시트에 motion 효과 구현 및 수정

## 📋 작업 내용

디테일 페이지 프로필 사진과 유저이름 구현: 현재 사용자가 아닌 플레이리스트를 생성한 유저를 뜨도록 코드 수정
댓글과 동영상 삭제 바텀시트에 motion 효과 구현 및 수정

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
<img width="574" alt="image" src="https://github.com/user-attachments/assets/73aa453b-2e6b-4b8b-bcf1-79b69d996448">

![Screen Recording 2024-09-26 at 6 18 32 PM](https://github.com/user-attachments/assets/c5619603-829d-4760-b9a1-d707ad30cb4c)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
